### PR TITLE
Fix: Snapshot image store for android

### DIFF
--- a/app/components/setup/draw-areas/index.js
+++ b/app/components/setup/draw-areas/index.js
@@ -9,7 +9,7 @@ import {
 
 import Config from 'react-native-config';
 import MapView from 'react-native-maps';
-import { storeImage } from 'helpers/fileManagement';
+import { storeImage, parseImagePath } from 'helpers/fileManagement';
 
 import ActionButton from 'components/common/action-button';
 import Theme from 'config/theme';
@@ -118,7 +118,7 @@ class DrawAreas extends Component {
         const snapshot = await this.takeSnapshot();
         const url = snapshot.uri ? snapshot.uri : snapshot;
         const storedUrl = await storeImage(url);
-        this.props.onDrawAreaFinish({ geostore }, storedUrl);
+        this.props.onDrawAreaFinish({ geostore }, parseImagePath(storedUrl));
       })
       .catch((error) => console.warn(error));
   }

--- a/app/components/setup/protected-areas/index.js
+++ b/app/components/setup/protected-areas/index.js
@@ -12,7 +12,7 @@ import {
 import Config from 'react-native-config';
 import MapView from 'react-native-maps';
 
-import { storeImage } from 'helpers/fileManagement';
+import { storeImage, parseImagePath } from 'helpers/fileManagement';
 import ActionButton from 'components/common/action-button';
 import Theme from 'config/theme';
 import I18n from 'locales';
@@ -138,7 +138,7 @@ class ProtectedAreas extends Component {
       this.props.onAreaSelected({
         wdpaid: this.state.wdpa.wdpa_pid,
         wdpaName: this.state.wdpa.name
-      }, storedUrl);
+      }, parseImagePath(storedUrl));
     });
   }
 

--- a/app/helpers/fileManagement.js
+++ b/app/helpers/fileManagement.js
@@ -1,22 +1,20 @@
+import { Platform } from 'react-native';
 import RNFetchBlob from 'react-native-fetch-blob';
 
 export async function storeImage(url) {
-  const dirs = RNFetchBlob.fs.dirs;
-  const imagesDir = `${dirs.DocumentDir}/images/`;
-  const newPath = `${dirs.DocumentDir}/images/${url.split('/').pop()}`;
+  const cleanedUrl = url.replace('file://', '');
+  const parentDirectory = RNFetchBlob.fs.dirs;
+  const imagesDirectory = `${parentDirectory.DocumentDir}/images`;
+  const newPath = `${imagesDirectory}/${cleanedUrl.split('/').pop()}`;
 
   try {
-    await RNFetchBlob.fs.isDir(imagesDir)
-    .then(async (isDir) => {
-      if (!isDir) {
-        RNFetchBlob.fs.mkdir(imagesDir)
-        .catch(() => {
-          // To-do error
-        });
-      }
-    });
+    const isDir = await RNFetchBlob.fs.isDir(imagesDirectory);
 
-    await RNFetchBlob.fs.mv(url, newPath)
+    if (!isDir) {
+      await RNFetchBlob.fs.mkdir(imagesDirectory);
+    }
+
+    await RNFetchBlob.fs.mv(cleanedUrl, newPath)
       .catch((error) => {
         // To-do error
       });
@@ -25,4 +23,14 @@ export async function storeImage(url) {
   } catch (error) {
     // To-do error
   }
+}
+
+export function parseImagePath(url) {
+  let parsedUrl = url;
+
+  if (Platform.OS === 'android') {
+    parsedUrl = `file://${parsedUrl}`;
+  }
+
+  return parsedUrl;
 }


### PR DESCRIPTION
Fixes the storing of images for android, `file` was missing from the URL. This is not needed for iOS.

Added a new helper to parse an URL before storing, if it's on Android it will add file:// before the path.