### PR TITLE
Feature/skip setup when areas

### DIFF
--- a/app/components/home/index.js
+++ b/app/components/home/index.js
@@ -26,7 +26,7 @@ class Home extends Component {
   }
 
   componentWillReceiveProps(newProps) {
-    if (newProps.loggedIn && !this.setup) {
+    if ((newProps.loggedIn && !this.setup) || (this.props.areasSynced !== newProps.areasSynced)) {
       this.checkSetup();
     }
   }
@@ -52,7 +52,17 @@ class Home extends Component {
       this.props.getUser();
     }
 
-    this.props.navigateReset(setupStatus ? 'Dashboard' : 'Setup');
+    if (userToken && !this.props.areasSynced) {
+      this.props.getAreas();
+    }
+
+    if (this.props.areasSynced) {
+      if (this.props.hasAreas) {
+        this.props.navigateReset('Dashboard');
+      } else {
+        this.props.navigateReset(setupStatus ? 'Dashboard' : 'Setup');
+      }
+    }
   }
 
   async checkBeforeRender() {
@@ -61,6 +71,9 @@ class Home extends Component {
     if (!userToken) {
       this.props.setLoginModal(true);
     } else {
+      if (!this.props.areasSynced && !this.props.hasAreas) {
+        this.props.getAreas();
+      }
       tracker.setUser(userToken);
       this.checkSetup();
     }
@@ -80,6 +93,9 @@ class Home extends Component {
 }
 
 Home.propTypes = {
+  getAreas: React.PropTypes.func.isRequired,
+  hasAreas: React.PropTypes.bool.isRequired,
+  areasSynced: React.PropTypes.bool.isRequired,
   getUser: React.PropTypes.func.isRequired,
   setIsConnected: React.PropTypes.func.isRequired,
   setLoginModal: React.PropTypes.func.isRequired,

--- a/app/components/reports/new/form.js
+++ b/app/components/reports/new/form.js
@@ -45,8 +45,8 @@ function getBtnTextByType(type) {
 
 function getBtnTextByPosition(position, total) {
   return position < total
-    ? I18n.t('report.next')
-    : I18n.t('report.save');
+    ? I18n.t('commonText.next')
+    : I18n.t('commonText.save');
 }
 
 function renderLoading() {

--- a/app/components/reports/new/form.js
+++ b/app/components/reports/new/form.js
@@ -45,8 +45,8 @@ function getBtnTextByType(type) {
 
 function getBtnTextByPosition(position, total) {
   return position < total
-    ? 'Next'
-    : 'Save';
+    ? I18n.t('report.next')
+    : I18n.t('report.save');
 }
 
 function renderLoading() {

--- a/app/components/setup/protected-areas/index.js
+++ b/app/components/setup/protected-areas/index.js
@@ -177,7 +177,7 @@ class ProtectedAreas extends Component {
     fetch(url)
       .then(response => {
         if (response.ok) return response.json();
-        throw Error(response);
+        throw Error(response.statusText);
       })
       .then((responseData) => {
         // this.setBoundaries(); Disabled by now

--- a/app/containers/home/index.js
+++ b/app/containers/home/index.js
@@ -1,11 +1,14 @@
 import { connect } from 'react-redux';
 import { setIsConnected } from 'redux-modules/app';
+import { getAreas } from 'redux-modules/areas';
 import { getUser, setLoginModal, setLoginStatus, checkLogged } from 'redux-modules/user';
 import { NavigationActions } from 'react-navigation';
 import Home from 'components/home';
 
 function mapStateToProps(state) {
   return {
+    hasAreas: state.areas.data && state.areas.data.length > 0,
+    areasSynced: state.areas.synced,
     loggedIn: state.user.loggedIn
   };
 }
@@ -39,6 +42,9 @@ function mapDispatchToProps(dispatch, { navigation }) {
     },
     setIsConnected: (isConnected) => {
       dispatch(setIsConnected(isConnected));
+    },
+    getAreas: () => {
+      dispatch(getAreas());
     }
   };
 }

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -2,6 +2,7 @@
 	"commonText": {
 		"appName": "Forest Watcher 2.0",
 		"next": "Next",
+    "save": "Save",
 		"back": "Back",
 		"finish": "Finish",
 		"setUp": "Set up",
@@ -92,9 +93,7 @@
     "uploadAll": "Upload All",
     "drafts": "Drafts",
     "uploaded": "Uploaded",
-    "reportIdRequired": "Report id is neccesary",
-    "next": "Next",
-    "save": "Save"
+    "reportIdRequired": "Report id is neccesary"
   },
   "feedback": {
     "title": "Feedback",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -92,7 +92,9 @@
     "uploadAll": "Upload All",
     "drafts": "Drafts",
     "uploaded": "Uploaded",
-    "reportIdRequired": "Report id is neccesary"
+    "reportIdRequired": "Report id is neccesary",
+    "next": "Next",
+    "save": "Save"
   },
   "feedback": {
     "title": "Feedback",

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -2,6 +2,7 @@
 	"commonText": {
 		"appName": "Forest Watcher 2.0",
 		"next": "Siguiente",
+    "save": "Guardar",
 		"back": "Atrás",
 		"finish": "Terminar",
 		"setUp": "Configuración",

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -2,6 +2,7 @@
 	"commonText": {
 		"appName": "Forest Watcher 2.0",
 		"next": "Suivant",
+    "save": "Enregistrer",
 		"back": "Précédent",
 		"finish": "Terminer",
 		"setUp": "Configurer",

--- a/app/locales/id.json
+++ b/app/locales/id.json
@@ -2,6 +2,7 @@
 	"commonText": {
 		"appName": "Forest Watcher 2.0",
 		"next": "Lanjut",
+    "save": "Menyimpan",
 		"back": "Kembali",
 		"finish": "Selesai",
 		"setUp": "Pengaturan",

--- a/app/locales/pt.json
+++ b/app/locales/pt.json
@@ -2,6 +2,7 @@
 	"commonText": {
 		"appName": "Forest Watcher 2.0",
 		"next": "Próximo",
+    "save": "Salve",
 		"back": "Voltar",
 		"finish": "Terminar",
 		"setUp": "Configuração",

--- a/app/redux-modules/alerts.js
+++ b/app/redux-modules/alerts.js
@@ -36,7 +36,7 @@ export function getAlerts(areaId) {
       })
     .then(response => {
       if (response.ok) return response.json();
-      throw Error(response);
+      throw Error(response.statusText);
     })
     .catch((error) => {
       console.warn(error);
@@ -66,7 +66,7 @@ export function getAlerts(areaId) {
           const points = await fetch(urlPoints)
             .then(response => {
               if (response.ok) return response.json();
-              throw Error(response);
+              throw Error(response.statusText);
             })
             .then(res => res.data)
             .catch((error) => {
@@ -96,7 +96,7 @@ export function getAlerts(areaId) {
           const points = await fetch(urlPoints)
             .then(response => {
               if (response.ok) return response.json();
-              throw Error(response);
+              throw Error(response.statusText);
             })
             .then(res => res.data)
             .catch((error) => {

--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -9,13 +9,14 @@ const SAVE_AREA = 'areas/SAVE_AREA';
 // Reducer
 const initialState = {
   data: [],
-  images: {}
+  images: {},
+  synced: false
 };
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
     case GET_AREAS:
-      return Object.assign({}, state, { ...action.payload });
+      return Object.assign({}, state, { ...action.payload, synced: true });
     case SAVE_AREA: {
       const areas = state.data.length > 0 ? state.data : [];
       const image = {};
@@ -46,7 +47,7 @@ export function getAreas() {
     })
       .then(response => {
         if (response.ok) return response.json();
-        throw Error(response);
+        throw Error(response.statusText);
       })
       .then((data) => {
         dispatch({
@@ -75,7 +76,7 @@ export function saveArea(params) {
     fetch(url, fetchConfig)
       .then(response => {
         if (response.ok) return response.json();
-        throw Error(response);
+        throw Error(response.statusText);
       })
       .then((res) => {
         dispatch({

--- a/app/redux-modules/countries.js
+++ b/app/redux-modules/countries.js
@@ -32,7 +32,7 @@ export function getCountries() {
     fetch(url)
       .then(response => {
         if (response.ok) return response.json();
-        throw Error(response);
+        throw Error(response.statusText);
       })
       .then((data) => {
         dispatch({

--- a/app/redux-modules/feedback.js
+++ b/app/redux-modules/feedback.js
@@ -56,7 +56,7 @@ export function getQuestions(type) {
     fetch(url, fetchConfig)
       .then(response => {
         if (response.ok) return response.json();
-        throw Error(response);
+        throw Error(response.statusText);
       })
       .then((data) => {
         let form = null;
@@ -171,7 +171,7 @@ export function uploadFeedback(type) {
       fetch(url, fetchConfig)
         .then((response) => {
           if (response.ok) return response.json();
-          throw Error(response);
+          throw Error(response.statusText);
         })
         .then((response) => {
           console.log('TODO: save response', response);

--- a/app/redux-modules/reports.js
+++ b/app/redux-modules/reports.js
@@ -51,7 +51,7 @@ export function getQuestions() {
     fetch(url, fetchConfig)
       .then(response => {
         if (response.ok) return response.json();
-        throw Error(response);
+        throw Error(response.statusText);
       })
       .then((data) => {
         let form = null;
@@ -163,7 +163,7 @@ export function uploadReport(reportName) {
       fetch(url, fetchConfig)
         .then((response) => {
           if (response.ok) return response.json();
-          throw Error(response);
+          throw Error(response.statusText);
         })
         .then((response) => {
           console.log('TODO: save response', response);

--- a/app/redux-modules/user.js
+++ b/app/redux-modules/user.js
@@ -49,7 +49,7 @@ export function checkLogged() {
     })
       .then(response => {
         if (response.ok) return response.json();
-        throw Error(response);
+        throw Error(response.statusText);
       })
       .then((data) => {
         dispatch({
@@ -58,7 +58,7 @@ export function checkLogged() {
         });
       })
       .catch((error) => {
-        console.warn(error);
+        console.log(error);
         // To-do
       });
   };
@@ -74,7 +74,7 @@ export function getUser() {
     })
       .then(response => {
         if (response.ok) return response.json();
-        throw Error(response);
+        throw Error(response.statusText);
       })
       .then((data) => {
         dispatch({


### PR DESCRIPTION
Skip the setup when the logged user already has areas.
TODO: review the home flow and use the store instead the AsyncStorage to save the userToken.

Localise the next and save form [here](https://github.com/Vizzuality/forest-watcher/compare/feature/skip-setup-when-areas?expand=1#diff-377ef3ed24a98bc1006ba64a2f38def9R48)

Fixed the yellow warning throwing the error text [here](https://github.com/Vizzuality/forest-watcher/compare/feature/skip-setup-when-areas?expand=1#diff-d76b0abf47b5e4ab5491fbaab8fc17d9R39)