### PR TITLE
Feature/map pop

### DIFF
--- a/app/components/alerts/index.js
+++ b/app/components/alerts/index.js
@@ -6,6 +6,7 @@ import {
 } from 'react-native';
 import tracker from 'helpers/googleAnalytics';
 
+import I18n from 'locales';
 import AlertsList from 'containers/alerts/list';
 import LeftBtn from 'components/common/header/left-btn';
 import Theme from 'config/theme';
@@ -70,7 +71,7 @@ Alerts.navigationOptions = {
     tintColor: Theme.colors.color1,
     style: headerStyles.style,
     titleStyle: headerStyles.titleStyle,
-    title: 'Alerts'
+    title: I18n.t('alerts.title')
   })
 };
 

--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -206,22 +206,23 @@ class Map extends Component {
       distanceText = `${distance} ${I18n.t('commonText.kmAway')}`; // in Kilometers
     }
 
-    let reportBtn = null;
     const createReport = () => {
       const form = `New-report-${Math.floor(Math.random() * 1000)}`;
-      this.props.createReport(form, `${lastPosition.latitude},${lastPosition.longitude}`);
-      this.props.navigation.navigate('NewReport', { form });
+      let latLng = '0,0';
+      if (lastPosition) {
+        latLng = `${lastPosition.latitude},${lastPosition.longitude}`;
+      }
+      this.props.createReport(form, latLng);
+      this.props.navigateReset('NewReport', { form });
     };
 
-    if (lastPosition) { // TODO: add distance validation
-      reportBtn = (
-        <ActionBtn
-          style={styles.footerButton}
-          text={I18n.t('report.title')}
-          onPress={() => createReport()}
-        />
-      );
-    }
+    const reportBtn = (
+      <ActionBtn
+        style={styles.footerButton}
+        text={I18n.t('report.title')}
+        onPress={() => createReport()}
+      />
+    );
     return (
       <View style={styles.footer}>
         <Image
@@ -342,6 +343,7 @@ class Map extends Component {
 
 Map.propTypes = {
   navigation: React.PropTypes.object.isRequired,
+  navigateReset: React.PropTypes.func.isRequired,
   createReport: React.PropTypes.func.isRequired
 };
 

--- a/app/containers/map/index.js
+++ b/app/containers/map/index.js
@@ -1,15 +1,27 @@
 import { connect } from 'react-redux';
 import { createReport } from 'redux-modules/reports';
+import { NavigationActions } from 'react-navigation';
 import Map from 'components/map';
 
 function mapStateToProps() {
   return {};
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, { navigation }) {
   return {
     createReport: (name, position) => {
       dispatch(createReport(name, position));
+    },
+    navigateReset: (routeName, params) => {
+      const action = NavigationActions.reset({
+        index: 2,
+        actions: [
+          { type: 'Navigate', routeName: 'Dashboard' },
+          { type: 'Navigate', routeName: 'Alerts' },
+          { type: 'Navigate', routeName, params }
+        ]
+      });
+      navigation.dispatch(action);
     }
   };
 }

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -38,7 +38,7 @@
 		"searchPlaceholder": "Search for a country"
 	},
 	"alerts": {
-		"title:": "Alerts",
+    "title": "Alerts",
 		"seeAll": "See all",
 		"alert": "alert",
     "downloadingAlerts": "Please wait while the data is downloaded..."

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -38,7 +38,7 @@
 		"searchPlaceholder": "Buscar un país"
 	},
 	"alerts": {
-		"title:": "Alertas",
+    "title": "Alertas",
 		"seeAll": "Ver todo",
 		"alert": "alerta",
     "downloadingAlerts": "Espera mientras se descargan los datos..."

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -38,7 +38,7 @@
 		"searchPlaceholder": "Rechercher un pays"
 	},
 	"alerts": {
-		"title:": "Alertes",
+    "title": "Alertes",
 		"seeAll": "Voir tout",
 		"alert": "alerte",
     "downloadingAlerts": "Veuillez patienter pendant le téléchargement des données..."

--- a/app/locales/id.json
+++ b/app/locales/id.json
@@ -38,7 +38,7 @@
 		"searchPlaceholder": "Cari negara"
 	},
 	"alerts": {
-		"title:": "Peringatan",
+    "title": "Peringatan",
 		"seeAll": "Lihat semua",
 		"alert": "Peringatan",
     "downloadingAlerts": "Harap tunggu sementara data yang di-download ..."

--- a/app/locales/pt.json
+++ b/app/locales/pt.json
@@ -38,7 +38,7 @@
 		"searchPlaceholder": "Procurar um país"
 	},
 	"alerts": {
-		"title:": "Alertas",
+    "title": "Alertas",
 		"seeAll": "Ver todos",
 		"alert": "alerta",
     "downloadingAlerts": "Aguarde enquanto os dados são baixados ..."


### PR DESCRIPTION
In map report button press pop the map view from the stack navigation to increase performance using the [navigationReset](https://github.com/Vizzuality/forest-watcher/compare/feature/map-pop?expand=1#diff-a34d3c2177b7afc8bdeedfaf6dde5bb9R15) action.

Also fix the alert view title locales.