### PR TITLE
Remove limit points for Peru

### DIFF
--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -89,7 +89,7 @@ class Map extends Component {
         longitudeDelta: LONGITUDE_DELTA
       },
       alertSelected: null,
-      alerts: params.features && params.features.length > 0 ? params.features.slice(0, 50) : [] // Provisional
+      alerts: params.features && params.features.length > 0 ? params.features.slice(0, 120) : [] // Provisional
     };
   }
 

--- a/app/redux-modules/alerts.js
+++ b/app/redux-modules/alerts.js
@@ -51,7 +51,8 @@ export function getAlerts(areaId, geojson) {
     });
 
     const areaGeojson = geojson.features[0];
-    const country = state().user.data.country || null;
+    const user = state().user;
+    const country = (user && user.data && user.data.country) || null;
 
     if (alerts) {
       await Promise.all(alerts.map(async (alert) => {

--- a/app/redux-modules/alerts.js
+++ b/app/redux-modules/alerts.js
@@ -51,6 +51,7 @@ export function getAlerts(areaId, geojson) {
     });
 
     const areaGeojson = geojson.features[0];
+    const country = state().user.data.country || null;
 
     if (alerts) {
       await Promise.all(alerts.map(async (alert) => {
@@ -67,11 +68,16 @@ export function getAlerts(areaId, geojson) {
         const geom = JSON.stringify(intersection.geometry);
 
         if (alert.countGlad > 0) {
+          let sql = `select lat, long from data
+            where year >= 2017
+            AND st_intersects(st_setsrid(st_geomfromgeojson('${geom}'), 4326), the_geom) LIMIT 60`;
+          if (country && country === 'PER') {
+            sql = `select lat, long from data
+              WHERE ((year = 2016 and julian_day >= 244) OR year > 2016)
+              AND st_intersects(st_setsrid(st_geomfromgeojson('${geom}'), 4326), the_geom)`;
+          }
           const dataset = Config.DATASET_GLAD;
-          const urlPoints = `${Config.API_URL}/query/${dataset}/?sql=
-          select lat, long from data
-          where year >= 2017
-          AND st_intersects(st_setsrid(st_geomfromgeojson('${geom}'), 4326), the_geom) LIMIT 60`;
+          const urlPoints = `${Config.API_URL}/query/${dataset}/?sql=${sql}`;
 
           const points = await fetch(urlPoints)
             .then(response => {


### PR DESCRIPTION
If the user has Peru as a country the map won't use the 60 alerts limit.

Remember to change it in your user profile.