### PR TITLE
Rollback camera update

### DIFF
--- a/app/components/common/form-inputs/blob/index.js
+++ b/app/components/common/form-inputs/blob/index.js
@@ -126,7 +126,7 @@ class ImageBlobInput extends Component {
         saving: true
       }, async () => {
         try {
-          const image = await this.camera.capture({ jpegQuality: 70 });
+          const image = await this.camera.capture();
           const storedUrl = await storeImage(image.path, true);
           this.setState({
             cameraVisible: false,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "geopoint": "^1.0.1",
     "react": "15.4.2",
     "react-native": "0.42.3",
-    "react-native-camera": "0.7.0",
+    "react-native-camera": "0.6.0",
     "react-native-config": "0.3.1",
     "react-native-datepicker": "1.4.5",
     "react-native-fetch-blob": "0.10.4",


### PR DESCRIPTION
As the new version is breaking in some android devices I've done a rollback of that change.

Remember to run `npm install`