### PR TITLE
Remove willUnmount from connection status

### DIFF
--- a/app/components/connectionstatus/index.js
+++ b/app/components/connectionstatus/index.js
@@ -12,10 +12,6 @@ class ConnectionStatus extends Component {
       });
   }
 
-  componentWillUnmount() {
-    NetInfo.isConnected.removeEventListener('change', this.handleConnectionChange);
-  }
-
   handleConnectionChange = (isConnected) => {
     this.props.setIsConnected(isConnected);
   };


### PR DESCRIPTION
The connected component in the dashboard was being unmounted just after mounting with the new navigation system