### PR TITLE
Fix: form save reset

### DIFF
--- a/app/components/common/form/index.js
+++ b/app/components/common/form/index.js
@@ -1,82 +1,32 @@
 import React, { Component } from 'react';
 import {
   Text,
-  View,
-  Alert
+  View
 } from 'react-native';
 
-import CONSTANTS from 'config/constants';
 import Theme from 'config/theme';
 import I18n from 'locales';
-import Form from 'containers/common/form';
+import FormStep from 'containers/common/form/form-step';
 import tracker from 'helpers/googleAnalytics';
 import styles from './styles';
 
-const saveReportIcon = require('assets/save_for_later.png');
-
-// Component necessary to set the navigationOptions
-class Reports extends Component {
+class Form extends Component {
   static navigatorStyle = {
     navBarTextColor: Theme.colors.color1,
     navBarButtonColor: Theme.colors.color1,
     topBarElevationShadowEnabled: false,
     navBarBackgroundColor: Theme.background.main
   };
-  static navigatorButtons = {
-    rightButtons: [
-      {
-        icon: saveReportIcon,
-        id: 'draft'
-      }
-    ]
-  };
-
-  constructor(props) {
-    super(props);
-    this.props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
-  }
 
   componentDidMount() {
     tracker.trackScreenView('Reports');
-  }
-
-  onPressDraft = () => {
-    const { form, texts } = this.props;
-    Alert.alert(
-      I18n.t(texts.saveLaterTitle),
-      I18n.t(texts.saveLaterDescription),
-      [
-        {
-          text: 'Cancel',
-          style: 'cancel'
-        },
-        {
-          text: 'OK',
-          onPress: () => {
-            if (this.props.saveReport) {
-              this.props.saveReport(form, {
-                status: CONSTANTS.status.draft
-              });
-            }
-            this.props.navigator.popToRoot({ animate: true });
-          }
-        }
-      ],
-      { cancelable: false }
-    );
-  }
-
-  onNavigatorEvent = (event) => {
-    if (event.type === 'NavBarButtonPress') {
-      if (event.id === 'draft') this.onPressDraft();
-    }
   }
 
   render() {
     const { form, step, texts, title, questionsToSkip, finish, screen } = this.props;
     const index = step || questionsToSkip;
     if (form) {
-      return (<Form
+      return (<FormStep
         form={form}
         index={index}
         navigator={this.props.navigator}
@@ -95,11 +45,10 @@ class Reports extends Component {
   }
 }
 
-Reports.propTypes = {
+Form.propTypes = {
   navigator: React.PropTypes.object.isRequired,
   form: React.PropTypes.string.isRequired,
   step: React.PropTypes.number,
-  saveReport: React.PropTypes.func,
   questionsToSkip: React.PropTypes.number,
   texts: React.PropTypes.object.isRequired,
   title: React.PropTypes.string.isRequired,
@@ -107,4 +56,4 @@ Reports.propTypes = {
   finish: React.PropTypes.func.isRequired
 };
 
-export default Reports;
+export default Form;

--- a/app/components/common/form/index.js
+++ b/app/components/common/form/index.js
@@ -58,7 +58,7 @@ class Reports extends Component {
                 status: CONSTANTS.status.draft
               });
             }
-            this.props.navigator.pop();
+            this.props.navigator.popToRoot({ animate: true });
           }
         }
       ],

--- a/app/components/reports/form.js
+++ b/app/components/reports/form.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import {
+  Alert
+} from 'react-native';
+
+import Form from 'components/common/form';
+import CONSTANTS from 'config/constants';
+import I18n from 'locales';
+
+const saveReportIcon = require('assets/save_for_later.png');
+
+class ReportForm extends Form {
+
+  static get navigatorStyle() {
+    return super.navigatorStyle;
+  }
+
+  static navigatorButtons = {
+    rightButtons: [
+      {
+        icon: saveReportIcon,
+        id: 'draft'
+      }
+    ]
+  };
+
+  constructor(props) {
+    super(props);
+    this.props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
+  }
+
+  onPressDraft = () => {
+    const { form, texts } = this.props;
+    Alert.alert(
+      I18n.t(texts.saveLaterTitle),
+      I18n.t(texts.saveLaterDescription),
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel'
+        },
+        {
+          text: 'OK',
+          onPress: () => {
+            if (this.props.saveReport) {
+              this.props.saveReport(form, {
+                status: CONSTANTS.status.draft
+              });
+            }
+            this.props.navigator.popToRoot({ animate: true });
+          }
+        }
+      ],
+      { cancelable: false }
+    );
+  }
+
+  onNavigatorEvent = (event) => {
+    if (event.type === 'NavBarButtonPress') {
+      if (event.id === 'draft') this.onPressDraft();
+    }
+  }
+}
+
+ReportForm.propTypes = {
+  saveReport: React.PropTypes.func
+};
+
+export default ReportForm;

--- a/app/containers/common/form/form-step.js
+++ b/app/containers/common/form/form-step.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { getBtnTextByType, getBtnTextByPosition } from 'helpers/forms';
-import ReportsForm from 'components/common/form/form-step';
+import FormStep from 'components/common/form/form-step';
 
 function getAnswers(forms, formName) {
   if (!forms) return null;
@@ -83,4 +83,4 @@ function mapStateToProps(state, { form, index, texts, questionsToSkip, finish, t
 export default connect(
   mapStateToProps,
   null
-)(ReportsForm);
+)(FormStep);

--- a/app/containers/reports/form.js
+++ b/app/containers/reports/form.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { saveReport, finishReport } from 'redux-modules/reports';
 
-import Form from 'components/common/form';
+import ReportForm from 'components/reports/form';
 
 function mapDispatchToProps(dispatch) {
   return {
@@ -17,4 +17,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
   null,
   mapDispatchToProps
-)(Form);
+)(ReportForm);

--- a/app/redux-modules/reports.js
+++ b/app/redux-modules/reports.js
@@ -101,8 +101,8 @@ export function uploadReport(reportName) {
     if (isConnected) {
       const report = state().form[reportName].values;
       const user = state().user;
-      const userName = (user && user.data && user.data && user.data.fullName) || 'Guest user';
-      const oganization = (user && user.data && user.data && user.data.organization) || 'None';
+      const userName = (user && user.data && user.data.fullName) || 'Guest user';
+      const oganization = (user && user.data && user.data.organization) || 'None';
       const reportStatus = state().reports.list[reportName];
 
       const form = new FormData();

--- a/app/screens/index.js
+++ b/app/screens/index.js
@@ -8,7 +8,7 @@ import Map from 'containers/map';
 import Settings from 'containers/settings';
 import Reports from 'containers/reports';
 import Feedback from 'containers/feedback';
-import NewReport from 'containers/reports/new';
+import NewReport from 'containers/reports/form';
 import AreaDetail from 'containers/settings/area-detail';
 import Partners from 'components/settings/partners';
 


### PR DESCRIPTION
This PR addresses the following issue(s):
- On save draft resets to root instead of popping current view.
- [ ] Renames Form component, Form container, Form-Step container to avoid confusion. 