### PR TITLE
Fix/update dates in map

### DIFF
--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -104,8 +104,7 @@ class Map extends Component {
       StatusBar.setBarStyle('light-content');
     }
 
-    const { dataset } = this.props;
-    const datasetSlug = dataset && dataset.slug;
+    const { datasetSlug } = this.props;
     this.setUrlTile(datasetSlug);
     this.renderMap();
     this.geoLocate();
@@ -116,7 +115,12 @@ class Map extends Component {
       this.setCompassLine();
     }
 
-    if (this.props.dataset.slug !== nextProps.dataset.slug) {
+    if (this.props.datasetSlug !== nextProps.datasetSlug) {
+      this.updateSelectedArea();
+    }
+
+    if (this.props.startDate !== nextProps.startDate ||
+        this.props.endDate !== nextProps.endDate) {
       this.updateSelectedArea();
     }
   }
@@ -198,8 +202,8 @@ class Map extends Component {
     }, () => {
       const options = { edgePadding: { top: 250, right: 250, bottom: 250, left: 250 }, animated: false };
       this.map.fitToCoordinates(this.props.area.coordinates, options);
-      if (this.props.dataset) {
-        this.setUrlTile(this.props.dataset.slug);
+      if (this.props.datasetSlug) {
+        this.setUrlTile(this.props.datasetSlug);
       }
     });
   }
@@ -392,13 +396,13 @@ class Map extends Component {
 
   render() {
     const { coordinates, alertSelected, urlTile, hasCompass, lastPosition, compassFallback } = this.state;
-    const { dataset } = this.props;
+    const { datasetSlug, startDate, endDate } = this.props;
     const hasCoordinates = (coordinates.tile && coordinates.tile.length > 0) || false;
     const showCompassFallback = !hasCompass && lastPosition && alertSelected && compassFallback;
 
     const dates = {
-      min: dataset.slug === 'viirs' ? String(dataset.startDate) : daysToDate(dataset.startDate),
-      max: dataset.slug === 'viirs' ? String(dataset.endDate) : daysToDate(dataset.endDate)
+      min: datasetSlug === 'viirs' ? String(startDate) : daysToDate(startDate),
+      max: datasetSlug === 'viirs' ? String(endDate) : daysToDate(endDate)
     };
 
     return (
@@ -477,7 +481,7 @@ class Map extends Component {
                 zIndex={-1}
                 maxZoom={12}
                 areaId={this.props.area.id}
-                alertType={dataset.slug}
+                alertType={datasetSlug}
                 isConnected={this.props.isConnected}
                 minDate={dates.min}
                 maxDate={dates.max}
@@ -490,7 +494,7 @@ class Map extends Component {
                 zIndex={1}
                 maxZoom={12}
                 areaId={this.props.area.id}
-                alertType={dataset.slug}
+                alertType={datasetSlug}
                 isConnected={this.props.isConnected}
                 minDate={dates.min}
                 maxDate={dates.max}
@@ -524,11 +528,9 @@ Map.propTypes = {
     lat: React.PropTypes.number.isRequired,
     lng: React.PropTypes.number.isRequired
   }),
-  dataset: React.PropTypes.shape({
-    slug: React.PropTypes.string.isRequired,
-    startDate: React.PropTypes.string.isRequired,
-    endDate: React.PropTypes.string.isRequired
-  })
+  startDate: React.PropTypes.string.isRequired,
+  endDate: React.PropTypes.string.isRequired,
+  datasetSlug: React.PropTypes.string.isRequired
 };
 
 export default Map;

--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -525,8 +525,8 @@ Map.propTypes = {
     coordinates: React.PropTypes.array.isRequired
   }).isRequired,
   center: React.PropTypes.shape({
-    lat: React.PropTypes.number.isRequired,
-    lng: React.PropTypes.number.isRequired
+    lat: React.PropTypes.number,
+    lng: React.PropTypes.number
   }),
   startDate: React.PropTypes.string.isRequired,
   endDate: React.PropTypes.string.isRequired,

--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -525,8 +525,8 @@ Map.propTypes = {
     coordinates: React.PropTypes.array.isRequired
   }).isRequired,
   center: React.PropTypes.shape({
-    lat: React.PropTypes.number,
-    lng: React.PropTypes.number
+    lat: React.PropTypes.number.isRequired,
+    lon: React.PropTypes.number.isRequired
   }),
   startDate: React.PropTypes.string.isRequired,
   endDate: React.PropTypes.string.isRequired,

--- a/app/containers/map/index.js
+++ b/app/containers/map/index.js
@@ -21,10 +21,16 @@ function mapStateToProps(state) {
   let parsedArea = {};
   let areaFeatures = null;
   let dataset = null;
+  let datasetSlug = null;
   let center = null;
   let areaCoordinates = null;
+  let startDate = null;
+  let endDate = null;
   if (area) {
     dataset = activeDataset(area);
+    datasetSlug = dataset.slug;
+    startDate = dataset.startDate;
+    endDate = dataset.endDate;
     areaFeatures = state.geostore.data[area.attributes.geostore].features[0];
     if (areaFeatures) {
       center = new BoundingBox(areaFeatures).getCenter();
@@ -39,7 +45,9 @@ function mapStateToProps(state) {
 
   return {
     area: parsedArea,
-    dataset,
+    datasetSlug,
+    startDate,
+    endDate,
     center,
     areaCoordinates,
     isConnected: state.offline.online


### PR DESCRIPTION
- Dates were not changing in the map when they were updated through the settings icon in the carousel:
  * startDate and EndDate were not updating the map because they were inside the datasets object which was not directly triggering the change even if it was modified

- Center prop can be null if there are not known lat and long so in the props these shouldn't be required