### PR TITLE
Return the selectedIndex to the prev area when one area is deleted

### DIFF
--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -152,7 +152,7 @@ class Map extends Component {
   }
 
   onLayout = () => {
-    if (this.hasSetCoordinates === false) {
+    if (this.hasSetCoordinates === false && this.props.areaCoordinates) {
       const options = { edgePadding: { top: 250, right: 250, bottom: 250, left: 250 }, animated: false };
       this.map.fitToCoordinates(this.props.areaCoordinates, options);
       this.hasSetCoordinates = true;

--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -79,7 +79,13 @@ export function saveAlertsToDb(areaId, slug, alerts) {
   if (alerts.length > 0) {
     const realm = initDb();
     const existingAlerts = realm.objects('Alert').filtered(`areaId = '${areaId}' AND slug = '${slug}'`);
-    realm.delete(existingAlerts);
+    try {
+      realm.write(() => {
+        realm.delete(existingAlerts);
+      });
+    } catch (e) {
+      console.warn('Error cleaning db', e);
+    }
 
     realm.write(() => {
       alerts.forEach((alert) => {

--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -288,7 +288,7 @@ export default function reducer(state = initialState, action) {
       if (typeof images[id] !== 'undefined') {
         images = omit(images, [id]);
       }
-      return { ...state, images, synced: true, syncing: false };
+      return { ...state, images, synced: true, syncing: false, selectedIndex: 0 };
     }
     case DELETE_AREA_ROLLBACK: {
       const data = [...state.data, action.meta.area];

--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -294,7 +294,21 @@ export default function reducer(state = initialState, action) {
       if (typeof images[id] !== 'undefined') {
         images = omit(images, [id]);
       }
-      return { ...state, images, synced: true, syncing: false, selectedIndex: 0 };
+      // Update the selectedIndex of the map
+      let selectedIndex = state.selectedIndex || 0;
+      if (selectedIndex > 0) {
+        let deletedIndex = 0;
+        for (let i = 0; i < state.data.length; i++) {
+          if (state.data[i].id === id) {
+            deletedIndex = i;
+            break;
+          }
+        }
+        if (deletedIndex <= selectedIndex) {
+          selectedIndex -= 1;
+        }
+      }
+      return { ...state, images, synced: true, syncing: false, selectedIndex };
     }
     case DELETE_AREA_ROLLBACK: {
       const data = [...state.data, action.meta.area];


### PR DESCRIPTION
The map was crashing because it wasn't returning to the first area when one area was deleted (and the area of the selected index was deleted)

Extra: Fix delete alerts before fetching. Clean of db for an areaId and slug