### PR TITLE
Redirect to setup if there are no areas

### DIFF
--- a/app/components/settings/index.js
+++ b/app/components/settings/index.js
@@ -34,6 +34,14 @@ class Settings extends Component {
     tracker.trackScreenView('Set Up');
   }
 
+  componentWillReceiveProps(props) {
+    if (props.areas.length === 0) {
+      props.navigator.push({
+        screen: 'ForestWatcher.Setup'
+      });
+    }
+  }
+
   onAreaPress = (areaId, name) => {
     this.props.navigator.push({
       screen: 'ForestWatcher.AreaDetail',


### PR DESCRIPTION
We check the props to redirect to setup page after we delete the last area