### PR TITLE
Fix: update partners text (english)

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -90,8 +90,8 @@
 	},
 	"partners": {
 	 	"title": "Partners",
-		"description": "Forest Watcher 2.0 is supported by a partnership of organizations contributing data, technology, funding and expertise.",
-		"listOfPartners": "See a full list of partners below."
+		"description": "Forest Watcher is created in collaboration between World Resources Institute, Vizzuality, and the Jane Goodall Institute.",
+		"listOfPartners": "See all Global Forest Watch partners."
 	},
 	"setupDrawAreas": {
     "invalidShape": "Invalid shape",


### PR DESCRIPTION
Update partners text from:
partners->description: "Forest Watcher 2.0 is supported by a partnership of organizations contributing data, technology, funding and expertise"
partners->listOfPartners: "See a full list of partners below"

To:
partners->description: "Forest Watcher is created in collaboration between World Resources Institute, Vizzuality, and the Jane Goodall Institute"
partners->listOfPartners: "See all Global Forest Watch partners"