### PR TITLE
Fix skip and only it when has alerts

### DIFF
--- a/app/components/dashboard/index.js
+++ b/app/components/dashboard/index.js
@@ -73,6 +73,7 @@ class Dashboard extends PureComponent {
   }
 
   onNavigatorEvent(event) {
+    const { actionsPending, syncModalOpen, syncSkip } = this.props;
     if (event.type === 'NavBarButtonPress') {
       if (event.id === 'settings') {
         this.props.navigator.push({
@@ -81,7 +82,8 @@ class Dashboard extends PureComponent {
         });
       }
     } else if (event.id === 'didAppear') {
-      if (this.props.actionsPending > 0 && !this.props.syncModalOpen) {
+      if (actionsPending > 0 && !syncModalOpen && !syncSkip && !this.syncModalOpen) {
+        this.syncModalOpen = true;
         this.props.setSyncModal(true);
         this.props.navigator.showModal({
           screen: 'ForestWatcher.Sync',
@@ -192,6 +194,7 @@ Dashboard.propTypes = {
   navigator: React.PropTypes.object.isRequired,
   actionsPending: React.PropTypes.number.isRequired,
   syncModalOpen: React.PropTypes.bool.isRequired,
+  syncSkip: React.PropTypes.bool.isRequired,
   setSyncModal: React.PropTypes.func.isRequired
 };
 

--- a/app/components/home/index.js
+++ b/app/components/home/index.js
@@ -12,6 +12,10 @@ class Home extends Component {
     navBarHidden: true
   };
 
+  componentWillMount() {
+    this.props.setSyncSkip(false);
+  }
+
   componentDidMount() {
     this.handleStatus();
     tracker.trackScreenView('Home');
@@ -23,7 +27,8 @@ class Home extends Component {
       this.props.loggedIn !== nextProps.loggedIn,
       this.props.syncFinished !== nextProps.syncFinished,
       this.props.hasAreas !== nextProps.hasAreas,
-      this.props.token !== nextProps.token
+      this.props.token !== nextProps.token,
+      this.props.syncSkip !== nextProps.syncSkip
     ];
     return conditions.includes(true);
   }
@@ -33,7 +38,7 @@ class Home extends Component {
   }
 
   handleStatus() {
-    const { loggedIn, token, hasAreas, syncFinished, setLanguage, navigator, syncModalOpen } = this.props;
+    const { loggedIn, token, hasAreas, syncFinished, syncSkip, setLanguage, navigator, syncModalOpen } = this.props;
     setLanguage();
     if (loggedIn) {
       tracker.setUser(token);
@@ -54,6 +59,11 @@ class Home extends Component {
             title: 'FOREST WATCHER'
           });
         }
+      } else if (syncSkip) {
+        navigator.resetTo({
+          screen: 'ForestWatcher.Dashboard',
+          title: 'FOREST WATCHER'
+        });
       }
     } else { // eslint-disable-line
       navigator.resetTo({
@@ -91,12 +101,14 @@ class Home extends Component {
 Home.propTypes = {
   loggedIn: React.PropTypes.bool.isRequired,
   token: React.PropTypes.string,
+  syncSkip: React.PropTypes.bool.isRequired,
   syncFinished: React.PropTypes.bool.isRequired,
   setLanguage: React.PropTypes.func.isRequired,
   navigator: React.PropTypes.object.isRequired,
   hasAreas: React.PropTypes.bool.isRequired,
   syncModalOpen: React.PropTypes.bool.isRequired,
-  setSyncModal: React.PropTypes.func.isRequired
+  setSyncModal: React.PropTypes.func.isRequired,
+  setSyncSkip: React.PropTypes.func.isRequired
 };
 Home.navigationOptions = {
   header: {

--- a/app/components/home/index.js
+++ b/app/components/home/index.js
@@ -44,7 +44,7 @@ class Home extends Component {
       tracker.setUser(token);
       if (!syncFinished && !syncModalOpen && !this.modalOpen) {
         this.openModal();
-      } else if (syncFinished) {
+      } else if (syncFinished || syncSkip) {
         if (!hasAreas) {
           navigator.resetTo({
             screen: 'ForestWatcher.Setup',
@@ -59,13 +59,8 @@ class Home extends Component {
             title: 'FOREST WATCHER'
           });
         }
-      } else if (syncSkip) {
-        navigator.resetTo({
-          screen: 'ForestWatcher.Dashboard',
-          title: 'FOREST WATCHER'
-        });
       }
-    } else { // eslint-disable-line
+    } else {
       navigator.resetTo({
         screen: 'ForestWatcher.Login'
       });

--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -139,8 +139,10 @@ class Map extends Component {
   }
 
   onNavigatorEvent(event) {
+    const { actionsPending, syncModalOpen, syncSkip } = this.props;
     if (event.id === 'didAppear') {
-      if (this.props.actionsPending > 0 && !this.props.syncModalOpen) {
+      if (actionsPending > 0 && !syncModalOpen && !syncSkip && !this.syncModalOpen) {
+        this.syncModalOpen = true;
         this.props.setSyncModal(true);
         this.props.navigator.showModal({
           screen: 'ForestWatcher.Sync',
@@ -513,6 +515,7 @@ Map.propTypes = {
   areaCoordinates: React.PropTypes.array,
   actionsPending: React.PropTypes.number.isRequired,
   syncModalOpen: React.PropTypes.bool.isRequired,
+  syncSkip: React.PropTypes.bool.isRequired,
   setSyncModal: React.PropTypes.func.isRequired
 };
 

--- a/app/components/setup/index.js
+++ b/app/components/setup/index.js
@@ -34,7 +34,8 @@ class Setup extends Component {
 
   onFinishSetup = () => {
     this.props.navigator.resetTo({
-      screen: 'ForestWatcher.Home'
+      screen: 'ForestWatcher.Dashboard',
+      title: 'FOREST WATCHER'
     });
   }
 

--- a/app/components/setup/index.js
+++ b/app/components/setup/index.js
@@ -32,9 +32,9 @@ class Setup extends Component {
     tracker.trackScreenView('Set Up');
   }
 
-  updatePage = (slide) => {
-    this.setState({
-      page: slide.i
+  onFinishSetup = () => {
+    this.props.navigator.resetTo({
+      screen: 'ForestWatcher.Home'
     });
   }
 
@@ -50,10 +50,9 @@ class Setup extends Component {
     }));
   }
 
-  onFinishSetup = () => {
-    this.props.navigator.resetTo({
-      screen: 'ForestWatcher.Dashboard',
-      title: 'FOREST WATCHER'
+  updatePage = (slide) => {
+    this.setState({
+      page: slide.i
     });
   }
 

--- a/app/containers/dashboard/index.js
+++ b/app/containers/dashboard/index.js
@@ -7,7 +7,8 @@ import { getTotalActionsPending } from 'helpers/sync';
 function mapStateToProps(state) {
   return {
     actionsPending: getTotalActionsPending(state),
-    syncModalOpen: state.app.syncModalOpen
+    syncModalOpen: state.app.syncModalOpen,
+    syncSkip: state.app.syncSkip
   };
 }
 

--- a/app/containers/home/index.js
+++ b/app/containers/home/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { setLanguage, setSyncModal } from 'redux-modules/app';
+import { setLanguage, setSyncModal, setSyncSkip } from 'redux-modules/app';
 import { setLoginStatus } from 'redux-modules/user';
 import { getLanguage } from 'helpers/language';
 import { isSyncFinished } from 'helpers/sync';
@@ -13,7 +13,8 @@ function mapStateToProps(state) {
     loggedIn: state.user.loggedIn,
     token: state.user.token,
     languageChanged: state.app.language !== getLanguage(),
-    syncModalOpen: state.app.syncModalOpen
+    syncModalOpen: state.app.syncModalOpen,
+    syncSkip: state.app.syncSkip
   };
 }
 
@@ -25,7 +26,8 @@ function mapDispatchToProps(dispatch) {
     setLanguageDispatch: () => {
       dispatch(setLanguage(getLanguage()));
     },
-    setSyncModal: open => dispatch(setSyncModal(open))
+    setSyncModal: open => dispatch(setSyncModal(open)),
+    setSyncSkip: open => dispatch(setSyncSkip(open))
   };
 }
 

--- a/app/containers/map/index.js
+++ b/app/containers/map/index.js
@@ -90,6 +90,7 @@ function mapStateToProps(state) {
     isConnected: state.offline.online,
     actionsPending: getTotalActionsPending(state),
     syncModalOpen: state.app.syncModalOpen,
+    syncSkip: state.app.syncSkip,
     alerts,
     datasetSlug
   };

--- a/app/containers/sync/index.js
+++ b/app/containers/sync/index.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
-import { syncApp, setSyncModal } from 'redux-modules/app';
-import { getLanguage } from 'helpers/language';
+import { syncApp, setSyncModal, setSyncSkip } from 'redux-modules/app';
 import { getTotalActionsPending } from 'helpers/sync';
 
 import Sync from 'components/sync';
@@ -8,8 +7,8 @@ import Sync from 'components/sync';
 function mapStateToProps(state) {
   return {
     isConnected: state.offline.online,
+    hasAreas: !!state.areas.data.length,
     reach: state.offline.netInfo && state.offline.netInfo.reach,
-    languageChanged: state.app.language !== getLanguage(),
     actionsPending: getTotalActionsPending(state)
   };
 }
@@ -17,7 +16,8 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     syncApp: () => dispatch(syncApp()),
-    setSyncModal: open => dispatch(setSyncModal(open))
+    setSyncModal: open => dispatch(setSyncModal(open)),
+    setSyncSkip: status => dispatch(setSyncSkip(status))
   };
 }
 

--- a/app/redux-modules/app.js
+++ b/app/redux-modules/app.js
@@ -7,12 +7,14 @@ import { getUser } from 'redux-modules/user';
 // Actions
 const SET_LANGUAGE = 'app/SET_LANGUAGE';
 const SET_SYNC_MODAL = 'app/SET_SYNC_MODAL';
+const SET_SYNC_SKIP = 'app/SET_SYNC_SKIP';
 
 // Reducer
 const initialState = {
   netInfo: null,
   language: null,
-  syncModalOpen: false
+  syncModalOpen: false,
+  syncSkip: false
 };
 
 export default function reducer(state = initialState, action) {
@@ -21,6 +23,8 @@ export default function reducer(state = initialState, action) {
       return Object.assign({}, state, { language: action.payload });
     case SET_SYNC_MODAL:
       return { ...state, syncModal: action.payload };
+    case SET_SYNC_SKIP:
+      return { ...state, syncSkip: action.payload };
     default:
       return state;
   }
@@ -28,19 +32,21 @@ export default function reducer(state = initialState, action) {
 
 // Action Creators
 export function setLanguage(language) {
-  return (dispatch) => {
-    dispatch({
-      type: SET_LANGUAGE,
-      payload: language
-    });
+  return {
+    type: SET_LANGUAGE,
+    payload: language
   };
 }
 export function setSyncModal(open) {
-  return (dispatch) => {
-    dispatch({
-      type: SET_SYNC_MODAL,
-      payload: open
-    });
+  return {
+    type: SET_SYNC_MODAL,
+    payload: open
+  };
+}
+export function setSyncSkip(status) {
+  return {
+    type: SET_SYNC_SKIP,
+    payload: status
   };
 }
 export function syncApp() {

--- a/app/redux-modules/app.js
+++ b/app/redux-modules/app.js
@@ -1,8 +1,8 @@
 import { getFeedbackQuestions } from 'redux-modules/feedback';
 import { getReportQuestions } from 'redux-modules/reports';
-import { syncAreas } from 'redux-modules/areas';
+import { syncAreas, UPDATE_AREA_REQUEST, SAVE_AREA_REQUEST } from 'redux-modules/areas';
 import { getCountries } from 'redux-modules/countries';
-import { getUser } from 'redux-modules/user';
+import { getUser, LOGOUT_REQUEST } from 'redux-modules/user';
 
 // Actions
 const SET_LANGUAGE = 'app/SET_LANGUAGE';
@@ -11,7 +11,6 @@ const SET_SYNC_SKIP = 'app/SET_SYNC_SKIP';
 
 // Reducer
 const initialState = {
-  netInfo: null,
   language: null,
   syncModalOpen: false,
   syncSkip: false
@@ -22,9 +21,15 @@ export default function reducer(state = initialState, action) {
     case SET_LANGUAGE:
       return Object.assign({}, state, { language: action.payload });
     case SET_SYNC_MODAL:
-      return { ...state, syncModal: action.payload };
+      return { ...state, syncModalOpen: action.payload };
     case SET_SYNC_SKIP:
       return { ...state, syncSkip: action.payload };
+    case UPDATE_AREA_REQUEST:
+      return { ...state, syncSkip: false };
+    case SAVE_AREA_REQUEST:
+      return { ...state, syncSkip: false };
+    case LOGOUT_REQUEST:
+      return initialState;
     default:
       return state;
   }

--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -436,7 +436,7 @@ export function saveArea(params) {
   const image = {
     uri: params.snapshot,
     type: 'image/png',
-    name: `${params.area.name}.png`
+    name: `${encodeURIComponent(params.area.name)}.png`
   };
   if (params.datasets) {
     body.append('datasets', JSON.stringify(params.datasets));

--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -16,13 +16,13 @@ const GET_AREAS_ROLLBACK = 'areas/GET_AREAS_ROLLBACK';
 const GET_ALERTS_REQUEST = 'areas/GET_ALERTS_REQUEST';
 const GET_ALERTS_COMMIT = 'areas/GET_ALERTS_COMMIT';
 const GET_ALERTS_ROLLBACK = 'areas/GET_ALERTS_ROLLBACK';
-const SAVE_AREA_REQUEST = 'areas/SAVE_AREA_REQUEST';
+export const SAVE_AREA_REQUEST = 'areas/SAVE_AREA_REQUEST';
 export const SAVE_AREA_COMMIT = 'areas/SAVE_AREA_COMMIT';
 export const SAVE_AREA_ROLLBACK = 'areas/SAVE_AREA_ROLLBACK';
 const GET_AREA_COVERAGE_REQUEST = 'areas/GET_AREA_COVERAGE_REQUEST';
 const GET_AREA_COVERAGE_COMMIT = 'areas/GET_AREA_COVERAGE_COMMIT';
 const GET_AREA_COVERAGE_ROLLBACK = 'areas/GET_AREA_COVERAGE_ROLLBACK';
-const UPDATE_AREA_REQUEST = 'areas/UPDATE_AREA_REQUEST';
+export const UPDATE_AREA_REQUEST = 'areas/UPDATE_AREA_REQUEST';
 const UPDATE_AREA_COMMIT = 'areas/UPDATE_AREA_COMMIT';
 const UPDATE_AREA_ROLLBACK = 'areas/UPDATE_AREA_ROLLBACK';
 const REMOVE_CACHE_AREA_REQUEST = 'areas/REMOVE_CACHE_AREA_REQUEST';
@@ -600,14 +600,16 @@ export function syncAreas() {
             syncAreasData((id) => {
               const area = getAreaById(state().areas.data, id);
               const { datasets } = area;
-              datasets.forEach((dataset) => {
-                if (dataset.cache) {
-                  dispatch(getAreaAlerts(id, dataset.slug));
-                } else {
-                  // TODO: remove this, cache will be mandatory
-                  // dispatch(removeCachedArea(id, dataset.slug));
-                }
-              });
+              if (datasets) {
+                datasets.forEach((dataset) => {
+                  if (dataset.cache) {
+                    dispatch(getAreaAlerts(id, dataset.slug));
+                  } else {
+                    // TODO: remove this, cache will be mandatory
+                    // dispatch(removeCachedArea(id, dataset.slug));
+                  }
+                });
+              }
             });
             break;
           default:


### PR DESCRIPTION
The skip button saves a flag in the state until the app is open again so we don't show the sync modal every time that we navigate between screens. It is hidden if we don't have the areas synced as they are necessary for the app.

Also, when we press on the sync in 3G shows the sync loading spinner.