### PR TITLE
Reset db on logout to remove old alerts

### DIFF
--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -99,6 +99,14 @@ export function saveAlertsToDb(areaId, slug, alerts) {
   }
 }
 
+export function resetAlertsDb() {
+  const realm = initDb();
+  realm.write(() => {
+    const allAlerts = realm.objects('Alert');
+    realm.delete(allAlerts);
+  });
+}
+
 export default function reducer(state = initialState, action) {
   switch (action.type) {
     case GET_AREAS_REQUEST:
@@ -329,6 +337,7 @@ export default function reducer(state = initialState, action) {
       return Object.assign({}, state, { selectedIndex: action.payload });
     }
     case LOGOUT_REQUEST: {
+      resetAlertsDb();
       return initialState;
     }
     default:


### PR DESCRIPTION
This PR removes the alerts stored in the database to avoid duplicated entries.