### PR TITLE
Fix/countries accents

### DIFF
--- a/app/components/common/search-selector/index.js
+++ b/app/components/common/search-selector/index.js
@@ -9,6 +9,7 @@ import {
   TextInput
 } from 'react-native';
 
+import deburr from 'lodash/deburr';
 import Theme from 'config/theme';
 import styles from './styles';
 
@@ -17,8 +18,8 @@ const closeImage = require('assets/close.png');
 
 function getFilteredData(data, filter) {
   if (!filter) return data;
-  const filterUpper = filter.toUpperCase();
-  return data.filter((item) => item.name.toUpperCase().indexOf(filterUpper) > -1);
+  const filterUpper = deburr(filter.toUpperCase());
+  return data.filter((item) => deburr(item.name.toUpperCase()).indexOf(filterUpper) > -1);
 }
 
 class SearchSelector extends Component {

--- a/app/redux-modules/feedback.js
+++ b/app/redux-modules/feedback.js
@@ -32,7 +32,7 @@ const initialState = {
 export default function reducer(state = initialState, action) {
   switch (action.type) {
     case GET_FEEDBACK_QUESTIONS_REQUEST: {
-      const { type } = action.payload;
+      const type = action.payload;
       const synced = { ...state.synced, [type]: false };
       const syncing = { ...state.syncing, [type]: true };
       return { ...state, synced, syncing };


### PR DESCRIPTION
This PR adresses the following issue(s):
- When downloading the feedback forms, the type received in the reducer was being read incorrectly thus the app never updated the synced flags and this forms were downloaded extra times.
- When searching countries the comparison between filter and data was taking into account the diacritical marks, now it deburrs the texts before comparing, thus rendering more matches.