### PR TITLE
fix: prevent-double-press-on-area-detail

### DIFF
--- a/app/components/settings/area-detail/index.js
+++ b/app/components/settings/area-detail/index.js
@@ -90,6 +90,7 @@ class AreaDetail extends Component {
         contentContainerStyle={styles.containerContent}
         showsVerticalScrollIndicator={false}
         showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps={'always'}
       >
         <View>
           <Text style={styles.title}>{I18n.t('commonText.name')}</Text>


### PR DESCRIPTION
This PR includes the following:
- Adds keyboardShouldPersistTaps prop to area-detail ScrollView to avoid having to double tap to perform an action. This issue occurred because the `TextInput` component had the focus thus tapping once removed the focus and tapping again performed the action.

> NOTE: This issue still needs to be resolved in the `SearchSelector` and the `Overview` components. This solution wasn't viable in these components because the input is not child of a `ScrollView` like in the `AreaDetail` component. Will address these issues in the future.