### PR TITLE
feat: adds fit bounds to area map before the screenshot

### DIFF
--- a/app/components/setup/draw-areas/index.js
+++ b/app/components/setup/draw-areas/index.js
@@ -162,6 +162,10 @@ class DrawAreas extends Component {
   }
 
   onNextPress = () => {
+    this.map.fitToCoordinates(this.state.shape.coordinates, {
+      edgePadding: { top: 0, right: 0, bottom: 0, left: 0 },
+      animated: true
+    });
     this.setState({ loading: true, snapshot: true });
     saveGeoJson(getGeoJson(this.state.shape.coordinates))
       .then(res => {

--- a/app/components/setup/draw-areas/index.js
+++ b/app/components/setup/draw-areas/index.js
@@ -163,8 +163,8 @@ class DrawAreas extends Component {
 
   onNextPress = () => {
     this.map.fitToCoordinates(this.state.shape.coordinates, {
-      edgePadding: { top: 0, right: 0, bottom: 0, left: 0 },
-      animated: true
+      edgePadding: { top: 100, right: 50, bottom: 100, left: 50 },
+      animated: false
     });
     this.setState({ loading: true, snapshot: true });
     saveGeoJson(getGeoJson(this.state.shape.coordinates))


### PR DESCRIPTION
This PR includes:
- Fit bounds of the create area map on clicking next. This ensures that the area picture is always centered. 🗺  📸  💪 