### PR TITLE
Fix: area-detail + map carousel styles polishing

### DIFF
--- a/app/components/map/area-carousel/index.js
+++ b/app/components/map/area-carousel/index.js
@@ -38,7 +38,7 @@ class AreaCarousel extends Component {
     let positionText = '';
     let datasetName = I18n.t('commonText.notAvailable');
     let distance = 999999;
-    const containerTextSyle = alertSelected
+    const containerTextStyle = alertSelected
       ? [styles.textContainer, styles.textContainerSmall]
       : styles.textContainer;
     if (lastPosition && (alertSelected && alertSelected.latitude && alertSelected.longitude)) {
@@ -67,42 +67,47 @@ class AreaCarousel extends Component {
       datasetName = enabledDatasetName(area) || NO_ALERT_SELECTED;
       return (
         <View key={`entry-${index}`} style={styles.slideInnerContainer}>
-          <Text style={containerTextSyle}>{ area.name } - { datasetName }</Text>
+          <Text style={containerTextStyle}>{ area.name } - { datasetName }</Text>
           {!alertSelected &&
-          <View style={styles.currentPosition}>
-            <Text style={styles.coordinateDistanceText}>
+          <View style={styles.lastUpdated}>
+            <Text style={styles.smallCarouselText}>
               {lastUpdatedText}
             </Text>
           </View>
-          }
-          {alertSelected &&
-            <View style={styles.currentPosition}>
-              <Text style={styles.coordinateDistanceText}>
-                {distanceText}
-              </Text>
-              <Text style={styles.coordinateDistanceText}>
-                {positionText}
-              </Text>
-            </View>
           }
           {settingsButton(area)}
         </View>
       );
     });
-
     return (
-      <View style={{ position: 'absolute', bottom: 0, zIndex: 10 }}>
-        <Carousel
-          ref={(carousel) => { this.carousel = carousel; }}
-          firstItem={selectedArea}
-          sliderWidth={sliderWidth}
-          itemWidth={itemWidth}
-          onSnapToItem={throttle((index) => this.props.updateSelectedArea(index), 300)}
-          showsHorizontalScrollIndicator={false}
-          slideStyle={styles.slideStyle}
-        >
-          { sliderItems }
-        </Carousel>
+      <View style={{ position: 'absolute', bottom: 0 }}>
+        {alertSelected &&
+          <View style={styles.currentPositionContainer}>
+            <View style={styles.currentPosition}>
+              <Text style={[styles.smallCarouselText, styles.coordinateDistanceText]}>
+                {distanceText}
+              </Text>
+              <Text style={[styles.smallCarouselText, styles.coordinateDistanceText]}>
+                {positionText}
+              </Text>
+            </View>
+          </View>
+        }
+        {!alertSelected &&
+          <Carousel
+            ref={(carousel) => {
+              this.carousel = carousel;
+            }}
+            firstItem={selectedArea}
+            sliderWidth={sliderWidth}
+            itemWidth={itemWidth}
+            onSnapToItem={throttle((index) => this.props.updateSelectedArea(index), 300)}
+            showsHorizontalScrollIndicator={false}
+            slideStyle={styles.slideStyle}
+          >
+            { sliderItems }
+          </Carousel>
+        }
       </View>
     );
   }

--- a/app/components/map/area-carousel/styles.js
+++ b/app/components/map/area-carousel/styles.js
@@ -10,11 +10,11 @@ function wp(percentage) {
   return Math.round(value);
 }
 const slideHeight = viewportHeight * 0.1;
-const slideWidth = wp(75);
-const itemHorizontalMargin = wp(2);
+const slideWidth = wp(85);
+const itemHorizontalMargin = wp(3);
 
 export const sliderWidth = viewportWidth;
-const horizontalMargin = itemHorizontalMargin * 2;
+const horizontalMargin = wp(2);
 export const itemWidth = slideWidth + horizontalMargin;
 
 const entryBorderRadius = 8;
@@ -36,8 +36,7 @@ export const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     width: itemWidth,
     height: slideHeight,
-    paddingHorizontal: itemHorizontalMargin,
-    paddingBottom: 18
+    paddingHorizontal: itemHorizontalMargin
   },
   textContainer: {
     justifyContent: 'center',
@@ -54,26 +53,36 @@ export const styles = StyleSheet.create({
   textContainerSmall: {
     paddingTop: 14 - entryBorderRadius
   },
-  carousel: {
-    flex: 0,
-    backgroundColor: 'transparent',
-    height: 134
-  },
   slideStyle: {
     backgroundColor: '#FFFFFF',
     borderTopLeftRadius: 5,
     borderTopRightRadius: 5
   },
-  coordinateDistanceText: {
+  smallCarouselText: {
     fontFamily: Theme.font,
     color: Theme.fontColors.secondary,
     fontSize: 14,
     fontWeight: '400',
     marginLeft: Theme.marginLeft * 2,
     backgroundColor: 'transparent',
-    lineHeight: 13
+    lineHeight: 22
+  },
+  coordinateDistanceText: {
+    color: Theme.fontColors.white
+  },
+  currentPositionContainer: {
+    bottom: 92,
+    paddingLeft: Theme.margin.left,
+    position: 'absolute',
+    width: Theme.screen.width,
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-start'
   },
   currentPosition: {
+    paddingBottom: 10
+  },
+  lastUpdated: {
     paddingTop: 3,
     position: 'relative'
   },

--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -334,9 +334,9 @@ class Map extends Component {
   selectAlert = (e) => {
     const { coordinate } = e.nativeEvent;
     if (coordinate) {
-      this.setState({
-        selectedAlertCoordinates: coordinate
-      });
+      this.setState((state) => ({
+        selectedAlertCoordinates: state.selectedAlertCoordinates ? null : coordinate
+      }));
     }
   }
 

--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -112,12 +112,14 @@ class Map extends Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     if (this.props.areaCoordinates !== prevProps.areaCoordinates) {
       this.updateSelectedArea();
     }
+    if (this.state.selectedAlertCoordinates !== prevState.selectedAlertCoordinates) {
+      this.setHeaderTitle();
+    }
   }
-
 
   componentWillUnmount() {
     Location.stopUpdatingLocation();
@@ -192,6 +194,16 @@ class Map extends Component {
         state.compassFallback = null;
       }
       return state;
+    });
+  }
+
+  setHeaderTitle = () => {
+    const { selectedAlertCoordinates } = this.state;
+    const headerText = selectedAlertCoordinates
+      ? `${selectedAlertCoordinates.latitude.toFixed(4)}, ${selectedAlertCoordinates.longitude.toFixed(4)}`
+      : I18n.t('dashboard.map');
+    this.props.navigator.setTitle({
+      title: headerText
     });
   }
 
@@ -340,12 +352,6 @@ class Map extends Component {
     }
   }
 
-  removeSelectedAlert = () => {
-    this.setState({
-      selectedAlertCoordinates: null
-    });
-  }
-
   updateSelectedArea = () => {
     this.setState({
       selectedAlertCoordinates: null
@@ -414,16 +420,6 @@ class Map extends Component {
       this.state.renderMap
       ?
         <View style={styles.container}>
-          <View
-            style={styles.header}
-            pointerEvents={'box-none'}
-          >
-            {selectedAlertCoordinates &&
-              <Text style={styles.headerSubtitle}>
-                {selectedAlertCoordinates.latitude.toFixed(4)}, {selectedAlertCoordinates.longitude.toFixed(4)}
-              </Text>
-            }
-          </View>
           <MapView
             ref={(ref) => { this.map = ref; }}
             style={styles.map}
@@ -495,7 +491,6 @@ class Map extends Component {
                 coordinate={selectedAlertCoordinates}
                 image={alertWhite}
                 anchor={{ x: 0.5, y: 0.5 }}
-                onPress={this.removeSelectedAlert}
                 zIndex={10}
               />
             }

--- a/app/components/map/index.js
+++ b/app/components/map/index.js
@@ -385,7 +385,7 @@ class Map extends Component {
 
   renderFooterLoading() {
     return (!this.state.lastPosition &&
-      <View style={styles.footer}>
+      <View pointerEvents="box-none" style={styles.footer}>
         <Image
           style={styles.footerBg}
           source={backgroundImage}
@@ -500,15 +500,15 @@ class Map extends Component {
               />
             }
           </MapView>
-          {selectedAlertCoordinates
-            ? this.renderFooter()
-            : this.renderFooterLoading()
-          }
           <AreaCarousel
             navigator={this.props.navigator}
             alertSelected={selectedAlertCoordinates}
             lastPosition={this.state.lastPosition}
           />
+          {selectedAlertCoordinates
+            ? this.renderFooter()
+            : this.renderFooterLoading()
+          }
         </View>
       : renderLoading()
     );

--- a/app/components/map/styles.js
+++ b/app/components/map/styles.js
@@ -45,21 +45,6 @@ export default StyleSheet.create({
       }
     })
   },
-  headerSubtitle: {
-    fontFamily: Theme.font,
-    color: Theme.fontColors.white,
-    fontSize: 16,
-    fontWeight: '400',
-    position: 'absolute',
-    zIndex: 2,
-    top: 46,
-    left: 56,
-    ...Platform.select({
-      ios: {
-        marginTop: 24
-      }
-    })
-  },
   headerBtn: {
     position: 'absolute',
     top: 8,

--- a/app/components/map/styles.js
+++ b/app/components/map/styles.js
@@ -143,7 +143,7 @@ export default StyleSheet.create({
   footerButton: {
     left: 8,
     right: 8,
-    bottom: 75,
+    bottom: 28,
     position: 'absolute',
     zIndex: 2
   },

--- a/app/components/settings/area-detail/index.js
+++ b/app/components/settings/area-detail/index.js
@@ -128,7 +128,7 @@ class AreaDetail extends Component {
         <View style={styles.row}>
           <Text style={styles.title}>{I18n.t('commonText.boundaries')}</Text>
           <View style={styles.imageContainer}>
-            <Image style={styles.image} source={{ uri: imageUrl || 'placeholder.png' }} />
+            <Image resizeMode="cover" style={styles.image} source={{ uri: imageUrl || 'placeholder.png' }} />
           </View>
         </View>
         <View style={styles.row}>

--- a/app/components/settings/area-detail/styles.js
+++ b/app/components/settings/area-detail/styles.js
@@ -25,9 +25,8 @@ export default StyleSheet.create({
     justifyContent: 'center'
   },
   image: {
-    width: 360,
-    height: 200,
-    resizeMode: 'cover'
+    width: Theme.screen.width,
+    height: 200
   },
   title: {
     marginLeft: Theme.margin.left,


### PR DESCRIPTION
This PR addresses the following issue(s):
- On the area-detail page, makes the area image occupy the whole width of the image container.
- On the map:
    - When an alert is selected hide the carousel and show the coordinates on the nav header. Also, display distance texts on top of the report button. When the alert is deselected restore the nav header title.
    - Improves deselect of alerts.