### PR TITLE
Feat: invalidate redux persist

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -30,6 +30,9 @@ export default () => {
           passProps: {}
         },
         disableOpenGesture: true
+      },
+      appStyle: {
+        orientation: 'portrait'
       }
     });
   }

--- a/app/offline/index.js
+++ b/app/offline/index.js
@@ -7,8 +7,12 @@ import { version } from 'package.json';
 import effect from './effect';
 
 const persistNative = (store, options, callback) => {
-  AsyncStorage.getItem('reduxPersist:app', (app) => {
+  AsyncStorage.getItem('reduxPersist:app', (err, appData) => {
     const getPersistedStore = () => persistStore(store, { storage: AsyncStorage, ...options }, callback);
+    let app = null;
+    if (!err) {
+      app = JSON.parse(appData);
+    }
     if (app && app.version !== version) {
       getPersistedStore().purge();
     } else {

--- a/app/offline/index.js
+++ b/app/offline/index.js
@@ -7,15 +7,14 @@ import { version } from 'package.json';
 import effect from './effect';
 
 const persistNative = (store, options, callback) => {
-  AsyncStorage.getItem('reduxPersist:app')
-    .then((app) => {
-      const getPersistedStore = () => persistStore(store, { storage: AsyncStorage, ...options }, callback); // .purge to clean the offline data
-      if (app.version !== version) {
-        getPersistedStore().purge();
-      } else {
-        getPersistedStore();
-      }
-    });
+  AsyncStorage.getItem('reduxPersist:app', (app) => {
+    const getPersistedStore = () => persistStore(store, { storage: AsyncStorage, ...options }, callback);
+    if (app && app.version !== version) {
+      getPersistedStore().purge();
+    } else {
+      getPersistedStore(); // .purge to clean the offline data
+    }
+  });
 };
 
 const config = params => ({

--- a/app/offline/index.js
+++ b/app/offline/index.js
@@ -3,11 +3,20 @@ import offlineConfig from 'redux-offline/lib/defaults';
 import detectNetwork from 'redux-offline/lib/defaults/detectNetwork.native';
 import { AsyncStorage } from 'react-native'; // eslint-disable-line import/no-unresolved
 import { persistStore } from 'redux-persist';
+import { version } from 'package.json';
 import effect from './effect';
 
-const persistNative = (store, options, callback) => (
-  persistStore(store, { storage: AsyncStorage, ...options }, callback) // .purge to clean the offline data
-);
+const persistNative = (store, options, callback) => {
+  AsyncStorage.getItem('reduxPersist:app')
+    .then((app) => {
+      const getPersistedStore = () => persistStore(store, { storage: AsyncStorage, ...options }, callback); // .purge to clean the offline data
+      if (app.version !== version) {
+        getPersistedStore().purge();
+      } else {
+        getPersistedStore();
+      }
+    });
+};
 
 const config = params => ({
   ...offlineConfig,

--- a/app/redux-modules/app.js
+++ b/app/redux-modules/app.js
@@ -1,3 +1,4 @@
+import { version } from 'package.json';
 import { getFeedbackQuestions } from 'redux-modules/feedback';
 import { getReportQuestions } from 'redux-modules/reports';
 import { syncAreas, UPDATE_AREA_REQUEST, SAVE_AREA_REQUEST } from 'redux-modules/areas';
@@ -15,7 +16,8 @@ const SET_SYNC_SKIP = 'app/SET_SYNC_SKIP';
 const initialState = {
   language: null,
   syncModalOpen: false,
-  syncSkip: false
+  syncSkip: false,
+  version // app cache invalidation depends on this, if this changes make sure that redux-persist invalidation changes also.
 };
 
 export default function reducer(state = initialState, action) {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
             "containers": "./app/containers",
             "redux-modules": "./app/redux-modules",
             "assets": "./app/assets",
-            "offline": "./app/offline"
+            "offline": "./app/offline",
+            "package.json": "./package.json"
           }
         }
       ]


### PR DESCRIPTION
This PR includes the following:
- On app init, the `package.json` version is compared with the persisted store version. If the two don't match, the persisted store is purged.

**[BONUS]**
- Makes the app portrait only.