### PR TITLE
fix: removes unused action + prevents area dataset mutation

### DIFF
--- a/app/components/settings/area-detail/alert-system/dataset-options/index.js
+++ b/app/components/settings/area-detail/alert-system/dataset-options/index.js
@@ -9,11 +9,6 @@ import DropdownPicker from 'components/settings/area-detail/alert-system/dropdow
 import styles from './styles';
 
 class DatasetOptions extends Component {
-  onChange = (currentValue) => {
-    const { id, dataset, setAreaDatasetCache } = this.props;
-    const updatedValue = !currentValue;
-    setAreaDatasetCache(id, dataset.slug, updatedValue);
-  }
 
   handleUpdateDate = (date) => {
     const { id, dataset, updateDate } = this.props;
@@ -46,8 +41,7 @@ DatasetOptions.propTypes = {
       React.PropTypes.number
     )
   }),
-  updateDate: PropTypes.func.isRequired,
-  setAreaDatasetCache: PropTypes.func.isRequired
+  updateDate: PropTypes.func.isRequired
 };
 
 export default DatasetOptions;

--- a/app/components/settings/area-detail/alert-system/index.js
+++ b/app/components/settings/area-detail/alert-system/index.js
@@ -58,7 +58,6 @@ class AlertSystem extends Component {
                   id={id}
                   dataset={dataset}
                   updateDate={this.props.updateDate}
-                  setAreaDatasetCache={this.props.setAreaDatasetCache}
                 />
                 : null
               }
@@ -81,8 +80,7 @@ AlertSystem.propTypes = {
     )
   }).isRequired,
   setAreaDatasetStatus: PropTypes.func.isRequired,
-  updateDate: PropTypes.func.isRequired,
-  setAreaDatasetCache: PropTypes.func.isRequired
+  updateDate: PropTypes.func.isRequired
 };
 
 export default AlertSystem;

--- a/app/containers/settings/area-detail/alert-system.js
+++ b/app/containers/settings/area-detail/alert-system.js
@@ -1,7 +1,7 @@
 
 
 import { connect } from 'react-redux';
-import { setAreaDatasetCache, setAreaDatasetStatus, updateDate } from 'redux-modules/areas';
+import { setAreaDatasetStatus, updateDate } from 'redux-modules/areas';
 import AlertSystem from 'components/settings/area-detail/alert-system';
 
 function mapStateToProps(state, { areaId }) {
@@ -13,9 +13,6 @@ function mapStateToProps(state, { areaId }) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    setAreaDatasetCache: (areaId, slug, cache) => {
-      dispatch(setAreaDatasetCache(areaId, slug, cache));
-    },
     setAreaDatasetStatus: (areaId, dataset, status) => {
       dispatch(setAreaDatasetStatus(areaId, dataset, status));
     },

--- a/app/helpers/area.js
+++ b/app/helpers/area.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 export function activeDataset(area) {
   if (area.datasets === undefined) return false;
-  const enabledDataset = area.datasets.find((d) => (d.active === true));
+  const enabledDataset = { ...area.datasets.find((d) => (d.active === true)) };
   if (typeof enabledDataset !== 'undefined') { return enabledDataset; }
   return false;
 }

--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -192,40 +192,30 @@ export default function reducer(state = initialState, action) {
       return { ...state, data, pendingData, synced: true, syncing: false };
     }
     case UPDATE_AREA_REQUEST: {
-      let pendingData = state.pendingData;
-      const { area: newArea, updateCache } = action.payload;
+      const { area: newArea } = action.payload;
       const areas = state.data.map((area) => {
         if (area.id === newArea.id) {
-          if (updateCache) {
-            pendingData = {
-              alert: { ...pendingData.alert, [area.id]: false }
-            };
-          }
           return { ...newArea };
         }
         return area;
       });
-      return { ...state, data: areas, pendingData, synced: false, syncing: true };
+      return { ...state, data: areas };
     }
     case UPDATE_AREA_COMMIT: {
       const newArea = action.payload;
       const data = state.data.map((area) => {
         if (area.id === newArea.id) {
-          return {
-            ...newArea
-          };
+          return { ...newArea };
         }
         return area;
       });
-      return { ...state, data, synced: true, syncing: false };
+      return { ...state, data };
     }
     case UPDATE_AREA_ROLLBACK: {
       const oldArea = action.meta;
       const areas = state.data.map((area) => {
         if (area.id === oldArea.id) {
-          return {
-            ...oldArea
-          };
+          return { ...oldArea };
         }
         return area;
       });
@@ -387,7 +377,7 @@ export function getAreaCoverage(areaId) {
   };
 }
 
-export function updateArea(area, updateCache) {
+export function updateArea(area) {
   return async (dispatch, state) => {
     const url = `${Config.API_URL}/area/${area.id}`;
     const originalArea = getAreaById(state().areas.data, area.id);
@@ -401,7 +391,7 @@ export function updateArea(area, updateCache) {
     }
     dispatch({
       type: UPDATE_AREA_REQUEST,
-      payload: { area, updateCache },
+      payload: { area },
       meta: {
         offline: {
           effect: { url, method: 'PATCH', headers, body },
@@ -464,22 +454,6 @@ export function removeCachedArea(areaId, datasetSlug) {
         }
       }
     });
-  };
-}
-
-export function setAreaDatasetCache(areaId, datasetSlug, cache) {
-  return async (dispatch, state) => {
-    const area = getAreaById(state().areas.data, areaId);
-    if (area) {
-      const datasets = area.datasets.map((dataset) => {
-        if (dataset.slug === datasetSlug) {
-          return { ...dataset, cache };
-        }
-        return dataset;
-      });
-      const newArea = { ...area, datasets };
-      dispatch(updateArea(newArea, true));
-    }
   };
 }
 


### PR DESCRIPTION
This PR addresses the following issue(s):
- Removes `setAreaDatasetCache` action from redux-module, container and components, because now cache is always true.
- Fixes an issue that prevented from changing alerts timeframe. This was due to a mutation of the dataset object included in the area object. ✌️ 