### PR TITLE
Fix: download progress retry issues

### DIFF
--- a/app/components/common/area-list/area-cache/index.js
+++ b/app/components/common/area-list/area-cache/index.js
@@ -13,7 +13,6 @@ import ProgressBar from 'react-native-progress/Bar';
 import Theme from 'config/theme';
 import styles from './styles';
 
-const Timer = require('react-native-timer');
 const downloadIcon = require('assets/download.png');
 const refreshIcon = require('assets/refresh.png');
 const downloadedIcon = require('assets/downloaded.png');
@@ -36,13 +35,17 @@ class AreaCache extends PureComponent {
   };
 
   state = {
-    indeterminate: !this.props.cacheStatus.requested,
+    indeterminate: this.props.cacheStatus.progress === 0,
     canRefresh: this.props.cacheStatus.completed
   };
 
   componentDidUpdate(prevProps) {
-    if (prevProps.cacheStatus.requested !== this.props.cacheStatus.requested) {
-      Timer.setTimeout(this, 'setIndeterminate', this.removeIndeterminate, 1000);
+    if (prevProps.cacheStatus.progress > 0 && this.props.cacheStatus.progress === 0) {
+      this.setIndeterminate(true);
+    }
+
+    if (prevProps.cacheStatus.progress === 0 && this.props.cacheStatus.progress > 0) {
+      this.setIndeterminate(false);
     }
 
     if (prevProps.cacheStatus.error !== this.props.cacheStatus.error && this.props.cacheStatus.error) {
@@ -55,10 +58,6 @@ class AreaCache extends PureComponent {
         ]
       );
     }
-  }
-
-  componentWillUnmount() {
-    Timer.clearTimeout(this, 'setIndeterminate');
   }
 
   onDownload = () => {
@@ -104,13 +103,13 @@ class AreaCache extends PureComponent {
     return refreshIcon;
   }
 
+  setIndeterminate = (indeterminate) => {
+    this.setState(() => ({ indeterminate }));
+  }
+
   resetCacheStatus = () => {
     const { areaId, resetCacheStatus } = this.props;
     resetCacheStatus(areaId);
-  }
-
-  removeIndeterminate = () => {
-    this.setState(() => ({ indeterminate: false }));
   }
 
   render() {

--- a/app/components/common/area-list/area-cache/index.js
+++ b/app/components/common/area-list/area-cache/index.js
@@ -31,7 +31,8 @@ class AreaCache extends PureComponent {
     isConnected: PropTypes.bool.isRequired,
     resetCacheStatus: PropTypes.func.isRequired,
     showTooltip: PropTypes.bool.isRequired,
-    refreshAreaCacheById: PropTypes.func.isRequired
+    refreshAreaCacheById: PropTypes.func.isRequired,
+    pendingCache: PropTypes.number.isRequired
   };
 
   state = {
@@ -48,7 +49,7 @@ class AreaCache extends PureComponent {
       this.setIndeterminate(false);
     }
 
-    if (prevProps.cacheStatus.error !== this.props.cacheStatus.error && this.props.cacheStatus.error) {
+    if (this.props.cacheStatus.error && prevProps.pendingCache > 0 && this.props.pendingCache === 0) {
       Alert.alert(
         I18n.t('commonText.error'),
         I18n.t('dashboard.downloadFailed'),

--- a/app/containers/dashboard/area-cache.js
+++ b/app/containers/dashboard/area-cache.js
@@ -2,11 +2,16 @@ import { connect } from 'react-redux';
 import { downloadAreaById, resetCacheStatus, refreshAreaCacheById } from 'redux-modules/layers';
 import AreaCache from 'components/common/area-list/area-cache';
 
+const getAreaPendingCache = (areaId, pendingCache) => Object.values(pendingCache)
+    .map((areas) => (typeof areas[areaId] !== 'undefined' ? 1 : 0))
+    .reduce((acc, next) => acc + next, 0);
+
 function mapStateToProps(state, { areaId }) {
   const cacheStatus = state.layers.cacheStatus[areaId];
   return {
     cacheStatus,
-    isConnected: state.offline.online
+    isConnected: state.offline.online,
+    pendingCache: getAreaPendingCache(areaId, state.layers.pendingCache)
   };
 }
 

--- a/app/redux-modules/geostore.js
+++ b/app/redux-modules/geostore.js
@@ -22,9 +22,10 @@ const initialState = {
 export default function reducer(state = initialState, action) {
   switch (action.type) {
     case STORE_GEOSTORE: {
-      const data = { ...state.data };
-      if (!data[action.payload.id]) {
-        data[action.payload.id] = action.payload;
+      const geostore = action.payload;
+      let data = { ...state.data };
+      if (!data[geostore.id]) {
+        data = { ...data, [geostore.id]: { id: geostore.id, ...geostore.data } };
       }
       return { ...state, data };
     }

--- a/app/redux-modules/layers.js
+++ b/app/redux-modules/layers.js
@@ -207,7 +207,8 @@ export default function reducer(state = initialState, action) {
         ...state.pendingCache,
         [layer.id]: omit(state.pendingCache[layer.id], [area.id])
       };
-      return { ...state, pendingCache, cacheStatus: newCacheStatus };
+      const layersProgress = omit(state.layersProgress, [area.id]);
+      return { ...state, pendingCache, cacheStatus: newCacheStatus, layersProgress };
     }
     case SET_CACHE_STATUS: {
       return { ...state, cacheStatus: action.payload };
@@ -280,7 +281,7 @@ function downloadAllLayers(config, dispatch) {
   return Promise.all(cacheZoom.map((cacheLevel) => {
     const layerConfig = { ...config, zoom: cacheLevel };
     return downloadLayer(layerConfig, dispatch);
-  }, this));
+  }));
 }
 
 


### PR DESCRIPTION
This PR includes the following changes:
- Shows progress bar indeterminate state until % > 0.
- Removes area from layersProgress on rollback to prevent showing misleading progress.
- Avoid showing cache error message until all layers have been processed.