### PR TITLE
Fix: creating areas crash

### DIFF
--- a/app/components/common/area-list/area-cache/index.js
+++ b/app/components/common/area-list/area-cache/index.js
@@ -35,9 +35,18 @@ class AreaCache extends PureComponent {
     pendingCache: PropTypes.number.isRequired
   };
 
+  static defaultProps = {
+    cacheStatus: {
+      progress: 0,
+      completed: false,
+      requested: false,
+      error: false
+    }
+  };
+
   state = {
-    indeterminate: this.props.cacheStatus ? this.props.cacheStatus.progress === 0 : true,
-    canRefresh: this.props.cacheStatus ? this.props.cacheStatus.completed : false
+    indeterminate: this.props.cacheStatus.progress === 0,
+    canRefresh: this.props.cacheStatus.completed
   };
 
   componentDidUpdate(prevProps) {

--- a/app/components/common/area-list/area-cache/index.js
+++ b/app/components/common/area-list/area-cache/index.js
@@ -36,8 +36,8 @@ class AreaCache extends PureComponent {
   };
 
   state = {
-    indeterminate: this.props.cacheStatus.progress === 0,
-    canRefresh: this.props.cacheStatus.completed
+    indeterminate: this.props.cacheStatus ? this.props.cacheStatus.progress === 0 : true,
+    canRefresh: this.props.cacheStatus ? this.props.cacheStatus.completed : false
   };
 
   componentDidUpdate(prevProps) {

--- a/app/components/setup/draw-areas/index.js
+++ b/app/components/setup/draw-areas/index.js
@@ -290,7 +290,7 @@ class DrawAreas extends Component {
   takeSnapshot() {
     return this.map.takeSnapshot({
       height: 224,
-      format: 'png',
+      format: 'jpg',
       quality: 0.8,
       result: 'file'
     });

--- a/app/redux-modules/alerts.js
+++ b/app/redux-modules/alerts.js
@@ -12,7 +12,7 @@ import CONSTANTS from 'config/constants';
 import { LOGOUT_REQUEST } from 'redux-modules/user';
 import { UPLOAD_REPORT_REQUEST } from 'redux-modules/reports';
 import { GET_AREA_COVERAGE_COMMIT } from 'redux-modules/areas';
-import { RETRY_SYNC } from 'redux-modules/app';
+import { START_APP, RETRY_SYNC } from 'redux-modules/app';
 
 const d3Dsv = require('d3-dsv');
 
@@ -65,6 +65,9 @@ const initialState = {
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
+    case START_APP: {
+      return { ...state, syncError: false, pendingData: {} };
+    }
     case RETRY_SYNC: {
       return { ...state, syncError: false };
     }


### PR DESCRIPTION
This PR includes the following:
- Adds default props to AreaCache to prevent crash when cacheStatus is empty.
- Changes snapshot format from `.png` to `.jpg` to prevent crash on area creation.
- Resets alerts pendingData and syncError on app start.