### PR TITLE
Fix: images not saved properly

### DIFF
--- a/app/components/common/area-list/area-cache/index.js
+++ b/app/components/common/area-list/area-cache/index.js
@@ -35,9 +35,18 @@ class AreaCache extends PureComponent {
     pendingCache: PropTypes.number.isRequired
   };
 
+  static defaultProps = {
+    cacheStatus: {
+      progress: 0,
+      completed: false,
+      requested: false,
+      error: false
+    }
+  };
+
   state = {
-    indeterminate: this.props.cacheStatus ? this.props.cacheStatus.progress === 0 : true,
-    canRefresh: this.props.cacheStatus ? this.props.cacheStatus.completed : false
+    indeterminate: this.props.cacheStatus.progress === 0,
+    canRefresh: this.props.cacheStatus.completed
   };
 
   componentDidUpdate(prevProps) {

--- a/app/components/common/area-list/area-cache/index.js
+++ b/app/components/common/area-list/area-cache/index.js
@@ -36,8 +36,8 @@ class AreaCache extends PureComponent {
   };
 
   state = {
-    indeterminate: this.props.cacheStatus.progress === 0,
-    canRefresh: this.props.cacheStatus.completed
+    indeterminate: this.props.cacheStatus ? this.props.cacheStatus.progress === 0 : true,
+    canRefresh: this.props.cacheStatus ? this.props.cacheStatus.completed : false
   };
 
   componentDidUpdate(prevProps) {

--- a/app/components/setup/draw-areas/index.js
+++ b/app/components/setup/draw-areas/index.js
@@ -290,7 +290,7 @@ class DrawAreas extends Component {
   takeSnapshot() {
     return this.map.takeSnapshot({
       height: 224,
-      format: 'png',
+      format: 'jpg',
       quality: 0.8,
       result: 'file'
     });

--- a/app/redux-modules/alerts.js
+++ b/app/redux-modules/alerts.js
@@ -12,7 +12,7 @@ import CONSTANTS from 'config/constants';
 import { LOGOUT_REQUEST } from 'redux-modules/user';
 import { UPLOAD_REPORT_REQUEST } from 'redux-modules/reports';
 import { GET_AREA_COVERAGE_COMMIT } from 'redux-modules/areas';
-import { RETRY_SYNC } from 'redux-modules/app';
+import { START_APP, RETRY_SYNC } from 'redux-modules/app';
 
 const d3Dsv = require('d3-dsv');
 
@@ -65,6 +65,9 @@ const initialState = {
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
+    case START_APP: {
+      return { ...state, syncError: false, pendingData: {} };
+    }
     case RETRY_SYNC: {
       return { ...state, syncError: false };
     }

--- a/app/redux-modules/areas.js
+++ b/app/redux-modules/areas.js
@@ -63,16 +63,15 @@ export default function reducer(state = initialState, action) {
     case GET_AREAS_COMMIT: {
       let pendingData = { ...state.pendingData };
       const data = [...action.payload];
-      const existingAreasID = state.data.length > 0
-        ? state.data.map((area) => area.id)
-        : [];
+      const existingImages = Object.keys(state.images);
       data.forEach((newArea) => {
         // Always request new coverage in case there are new alert system in the area
         pendingData = {
-          coverage: { ...pendingData.coverage, [newArea.id]: false }
+          coverage: { ...pendingData.coverage, [newArea.id]: false },
+          image: { ...pendingData.image }
         };
         // and only cache the images if is a new area
-        if (!existingAreasID.includes(newArea.id)) {
+        if (!existingImages.includes(newArea.id)) {
           pendingData = {
             ...pendingData,
             image: { ...pendingData.image, [newArea.id]: false }


### PR DESCRIPTION
This PR includes: 
- Fix not all area images downloaded correctly. Every time that a new `pendingData.coverage` key was added, all the existing `pendingData.image` keys were being deleted.
- Changes check for existence from the area list to the image dictionary, for coherence.