### PR TITLE
Fix: done button not showing

### DIFF
--- a/app/components/common/area-list/index.js
+++ b/app/components/common/area-list/index.js
@@ -4,7 +4,8 @@ import {
   Image,
   Text,
   TouchableHighlight,
-  View
+  View,
+  Platform
 } from 'react-native';
 import Theme from 'config/theme';
 
@@ -45,7 +46,7 @@ function AreaList(props) {
               </TouchableHighlight>
             </View>
           </TouchableHighlight>
-          {showCache &&
+          {showCache && Platform.OS === 'android' &&
             <AreaCache areaId={area.id} showTooltip={index === 0 && pristine} />
           }
         </View>

--- a/app/components/dashboard/index.js
+++ b/app/components/dashboard/index.js
@@ -52,7 +52,7 @@ class Dashboard extends PureComponent {
     super(props);
     this.props.navigator.setOnNavigatorEvent(this.onNavigatorEvent);
     this.state = {
-      pristine: true
+      pristine: Platform.OS === 'android'
     };
     this.reportsAction = {
       callback: this.onPressReports,


### PR DESCRIPTION
This PR addresses the following:
- Disables cache functionality on iOS
- Issue introduced in (5197f596007358d9dd248d6262c6eeeb777fb60e) that showed the downloaded button when a download failed partially and the last layer was a success.
- Improvement in `layersProgress` logic that sets:
    - progress = 1 on commit
    - progress = 0 on rollback