### PR TITLE
fix: area-list component arrow button is now only an icon

### DIFF
--- a/app/components/common/area-list/index.js
+++ b/app/components/common/area-list/index.js
@@ -36,13 +36,7 @@ function AreaList(props) {
               <View style={styles.titleContainer}>
                 <Text style={styles.title} numberOfLines={2}> {area.name} </Text>
               </View>
-              <TouchableHighlight
-                activeOpacity={0.5}
-                underlayColor="transparent"
-                onPress={() => onAreaPress(area.id, area.name)}
-              >
-                <Image style={Theme.icon} source={nextIcon} />
-              </TouchableHighlight>
+              <Image style={Theme.icon} source={nextIcon} />
             </View>
           </TouchableHighlight>
           {showCache &&


### PR DESCRIPTION
This PR is super trivial. The `<AreaList />` used to have as a clickable area an arrow button. Then, the clickable area changed to be everything and the arrow button should've changed to just a plain arrow icon: it didn't. This PR removes the button, leaving just the icon. 