### PR TITLE
feat: add-data-loss-warning

### DIFF
--- a/app/components/settings/index.js
+++ b/app/components/settings/index.js
@@ -34,7 +34,8 @@ class Settings extends Component {
     areas: PropTypes.any,
     navigator: PropTypes.object.isRequired,
     logout: PropTypes.func.isRequired,
-    isConnected: PropTypes.bool.isRequired
+    isConnected: PropTypes.bool.isRequired,
+    isUnsafeLogout: PropTypes.bool.isRequired
   };
 
   componentDidMount() {
@@ -60,10 +61,26 @@ class Settings extends Component {
   }
 
   onLogoutPress = () => {
-    this.props.logout();
-    this.props.navigator.resetTo({
-      screen: 'ForestWatcher.Home'
-    });
+    const { logout, navigator, isUnsafeLogout } = this.props;
+    const proceedWithLogout = () => {
+      logout();
+      navigator.resetTo({
+        screen: 'ForestWatcher.Home'
+      });
+    };
+    if (isUnsafeLogout) {
+      Alert.alert(
+        I18n.t('settings.unsafeLogout'),
+        I18n.t('settings.unsavedDataLost'),
+        [
+          { text: 'OK', onPress: proceedWithLogout },
+          {
+            text: 'Cancel',
+            style: 'cancel'
+          }
+        ]
+      );
+    } else proceedWithLogout();
   }
 
   onPressAddArea = () => {

--- a/app/components/setup/header/index.js
+++ b/app/components/setup/header/index.js
@@ -17,6 +17,22 @@ const layersIcon = require('assets/layers.png');
 
 class SetupHeader extends Component {
 
+  static propTypes = {
+    title: PropTypes.string,
+    navigator: PropTypes.object,
+    setShowLegend: PropTypes.func.isRequired,
+    logout: PropTypes.func.isRequired,
+    showBack: PropTypes.bool,
+    onBackPress: (props, propName, componentName) => {
+      if (props.showBack && !props[propName]) {
+        return new Error(`${I18n.t('setupHeader.errorFirst')} ${propName}
+      ${I18n.t('setupHeader.errorSecond')}  ${componentName}. ${I18n.t('setupHeader.errorThird')}`);
+      }
+      return null;
+    },
+    page: PropTypes.number.isRequired
+  };
+
   onContextualLayersPress = () => {
     this.props.setShowLegend(false);
     this.props.navigator.toggleDrawer({
@@ -85,21 +101,5 @@ class SetupHeader extends Component {
     );
   }
 }
-
-SetupHeader.propTypes = {
-  title: PropTypes.string,
-  navigator: PropTypes.object,
-  setShowLegend: PropTypes.func.isRequired,
-  logout: PropTypes.func.isRequired,
-  showBack: PropTypes.bool,
-  onBackPress: (props, propName, componentName) => {
-    if (props.showBack && !props[propName]) {
-      return new Error(`${I18n.t('setupHeader.errorFirst')} ${propName}
-      ${I18n.t('setupHeader.errorSecond')}  ${componentName}. ${I18n.t('setupHeader.errorThird')}`);
-    }
-    return null;
-  },
-  page: PropTypes.number.isRequired
-};
 
 export default SetupHeader;

--- a/app/components/setup/index.js
+++ b/app/components/setup/index.js
@@ -18,6 +18,14 @@ class Setup extends Component {
     navBarHidden: true
   };
 
+  static propTypes = {
+    navigator: PropTypes.object.isRequired,
+    setShowLegend: PropTypes.func.isRequired,
+    logout: PropTypes.func.isRequired,
+    initSetup: PropTypes.func.isRequired,
+    goBackDisabled: PropTypes.bool
+  };
+
   state = {
     page: 0
   };
@@ -92,13 +100,5 @@ class Setup extends Component {
     );
   }
 }
-
-Setup.propTypes = {
-  navigator: PropTypes.object.isRequired,
-  setShowLegend: PropTypes.func.isRequired,
-  logout: PropTypes.func.isRequired,
-  initSetup: PropTypes.func.isRequired,
-  goBackDisabled: PropTypes.bool
-};
 
 export default Setup;

--- a/app/containers/settings/index.js
+++ b/app/containers/settings/index.js
@@ -1,10 +1,12 @@
 import { connect } from 'react-redux';
+import { isUnsafeLogout } from 'helpers/user';
 import { logout } from 'redux-modules/user';
 
 import Settings from 'components/settings';
 
 function mapStateToProps(state) {
   return {
+    isUnsafeLogout: isUnsafeLogout(state),
     user: state.user.data,
     loggedIn: state.user.loggedIn,
     areas: state.areas.data,
@@ -12,11 +14,8 @@ function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps(dispatch, { navigation }) {
+function mapDispatchToProps(dispatch) {
   return {
-    navigate: (routeName, params) => {
-      navigation.navigate(routeName, params);
-    },
     logout: () => {
       dispatch(logout());
     }

--- a/app/helpers/user.js
+++ b/app/helpers/user.js
@@ -1,0 +1,11 @@
+import { STATUS } from 'config/constants/index';
+
+export function isUnsafeLogout({ reports }) {
+  const { list } = reports;
+  const hasReportsToUpload = type => (type === STATUS.complete) || (type === STATUS.draft);
+  return Object.values(list)
+    .map(report => report.status)
+    .some(hasReportsToUpload);
+}
+
+export default { isUnsafeLogout };

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -483,7 +483,9 @@
         "connectionRequired": "You need an internet connection",
         "coordinatesFormat": "Coordinates Format",
         "coordinatesDecimal": "Decimal",
-        "coordinatesDegrees": "Degrees"
+        "coordinatesDegrees": "Degrees",
+        "unsafeLogout": "Your reports are not synced!",
+        "unsavedDataLost": "If you proceed with the logout all your unsaved data will be lost."
     },
     "report": {
         "title": "Report",

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -483,13 +483,15 @@
         "connectionRequired": "Tienes que tener una conexión a Internet",
         "coordinatesFormat": "Coordina el formato",
         "coordinatesDecimal": "Decimal",
-        "coordinatesDegrees": "Grados"
+        "coordinatesDegrees": "Grados",
+        "unsafeLogout": "Your reports are not synced!",
+        "unsavedDataLost": "If you proceed with the logout all your unsaved data will be lost."
     },
     "report": {
         "title": "Informe",
         "plural": "Informes",
         "selected": "Informe seleccionado",
-        "area": "Informar área",
+        "area": "Area del informe",
         "takePicture": "Toma una foto",
         "choosePicture": "Por favor, haz o elige una foto",
         "datePlaceholder": "Seleccione una fecha",

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -483,7 +483,9 @@
         "connectionRequired": "Vous avez besoin d'une connexion à internet",
         "coordinatesFormat": "Coordonne le format",
         "coordinatesDecimal": "Décimal",
-        "coordinatesDegrees": "Degrés"
+        "coordinatesDegrees": "Degrés",
+        "unsafeLogout": "Your reports are not synced!",
+        "unsavedDataLost": "If you proceed with the logout all your unsaved data will be lost."
     },
     "report": {
         "title": "Rapport",

--- a/app/locales/id.json
+++ b/app/locales/id.json
@@ -483,7 +483,9 @@
         "connectionRequired": "Anda membutuhkan koneksi internet",
         "coordinatesFormat": "Format Koordinat",
         "coordinatesDecimal": "Desimal",
-        "coordinatesDegrees": "Derajat"
+        "coordinatesDegrees": "Derajat",
+        "unsafeLogout": "Your reports are not synced!",
+        "unsavedDataLost": "If you proceed with the logout all your unsaved data will be lost."
     },
     "report": {
         "title": "Lapor",

--- a/app/locales/pt.json
+++ b/app/locales/pt.json
@@ -483,7 +483,9 @@
         "connectionRequired": "Precisa de uma conexão à Internet",
         "coordinatesFormat": "Formato das Coordenadas",
         "coordinatesDecimal": "Decimal",
-        "coordinatesDegrees": "Graus"
+        "coordinatesDegrees": "Graus",
+        "unsafeLogout": "Your reports are not synced!",
+        "unsavedDataLost": "If you proceed with the logout all your unsaved data will be lost."
     },
     "report": {
         "title": "Relatório",


### PR DESCRIPTION
This PR includes:
- New `helpers/user.js` that includes a check for unsafe logouts
- Adds logout warning on the settings page, noticing the user that if he proceeds he'll lose the unsaved reports and drafts.