### PR TITLE
Fix offline not starting after rehydrate

### DIFF
--- a/app/store.js
+++ b/app/store.js
@@ -48,7 +48,7 @@ function createAppStore(startApp) {
   }
   return storeCreator(
     enhanceReducer(reducer),
-    compose(middleware, enhanceStore)
+    compose(enhanceStore, middleware)
   );
 }
 


### PR DESCRIPTION
Order matters, swapping two words could fix a critical bug 🎉 

The offline middleware wasn't aware of the outbox actions after rehydrate until another action was dispatched, so when the app starts and it doesn't dispatch any other action the offline wouldn't start and the actions would remain there forever.

Now the middleware is applied first and all of the actions go through it, including the rehydrate one.

Reference: https://redux.js.org/api-reference/compose 
Key: `Composes functions from right to left.`